### PR TITLE
Fix Stripe search query injection vulnerability

### DIFF
--- a/packages/cli/src/commands/diff.ts
+++ b/packages/cli/src/commands/diff.ts
@@ -106,19 +106,19 @@ export default class Diff extends Command {
    */
   private async fetchCurrentResource(stripe: Stripe, resource: any): Promise<any> {
     try {
-      // Escape single quotes in resource.id to prevent search query injection
-      const escapedId = resource.id.replace(/'/g, "\\'");
+      // Escape backslashes first, then escape double quotes in resource.id to prevent search query injection
+      const escapedId = resource.id.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
       switch (resource.type) {
         case 'Stripe::Product': {
           const result = await stripe.products.search({
-            query: `metadata['pricectl_id']:'${escapedId}' OR metadata['fillet_id']:'${escapedId}'`,
+            query: `metadata["pricectl_id"]:"${escapedId}" OR metadata["fillet_id"]:"${escapedId}"`,
             limit: 1,
           });
           return result.data.length > 0 ? result.data[0] : null;
         }
         case 'Stripe::Price': {
           const result = await stripe.prices.search({
-            query: `metadata['pricectl_id']:'${escapedId}' OR metadata['fillet_id']:'${escapedId}'`,
+            query: `metadata["pricectl_id"]:"${escapedId}" OR metadata["fillet_id"]:"${escapedId}"`,
             limit: 1,
           });
           return result.data.length > 0 ? result.data[0] : null;

--- a/packages/cli/src/engine/deployer.ts
+++ b/packages/cli/src/engine/deployer.ts
@@ -212,11 +212,11 @@ export class StripeDeployer {
 
   private async findExistingProduct(logicalId: string): Promise<Stripe.Product | null> {
     try {
-      // Escape single quotes in logicalId to prevent search query injection
-      const escapedId = logicalId.replace(/'/g, "\\'");
+      // Escape backslashes first, then escape double quotes in logicalId to prevent search query injection
+      const escapedId = logicalId.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
       // Use search API with OR query to support both old and new metadata keys
       const result = await this.stripe.products.search({
-        query: `metadata['pricectl_id']:'${escapedId}' OR metadata['fillet_id']:'${escapedId}'`,
+        query: `metadata["pricectl_id"]:"${escapedId}" OR metadata["fillet_id"]:"${escapedId}"`,
         limit: 1,
       });
 
@@ -237,11 +237,11 @@ export class StripeDeployer {
 
   private async findExistingPrice(logicalId: string): Promise<Stripe.Price | null> {
     try {
-      // Escape single quotes in logicalId to prevent search query injection
-      const escapedId = logicalId.replace(/'/g, "\\'");
+      // Escape backslashes first, then escape double quotes in logicalId to prevent search query injection
+      const escapedId = logicalId.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
       // Use search API with OR query to support both old and new metadata keys
       const result = await this.stripe.prices.search({
-        query: `metadata['pricectl_id']:'${escapedId}' OR metadata['fillet_id']:'${escapedId}'`,
+        query: `metadata["pricectl_id"]:"${escapedId}" OR metadata["fillet_id"]:"${escapedId}"`,
         limit: 1,
       });
 


### PR DESCRIPTION
## Summary
This PR fixes a security vulnerability in Stripe search queries by properly escaping special characters. The previous implementation used single quote escaping, which is ineffective for the Stripe search API syntax. This change updates the escaping strategy to properly handle backslashes and double quotes, which are the actual delimiters used in Stripe's search query syntax.

## Key Changes
- Updated `findExistingProduct()` in `deployer.ts` to escape backslashes and double quotes instead of single quotes
- Updated `findExistingPrice()` in `deployer.ts` with the same escaping fix
- Updated `fetchCurrentResource()` in `diff.ts` to use the corrected escaping strategy
- Changed search query syntax from single quotes to double quotes to match Stripe API requirements
- Escaping now follows the correct order: backslashes first, then double quotes

## Implementation Details
- The escaping chain `replace(/\\/g, '\\\\').replace(/"/g, '\\"')` ensures that:
  1. Existing backslashes are escaped first to prevent double-escaping
  2. Double quotes are then escaped to prevent query injection
- Search queries now use the format `metadata["key"]:"value"` instead of `metadata['key']:'value'`
- Changes applied consistently across three search query locations in the codebase

https://claude.ai/code/session_016oVsmjHzatwcbYeDxbKXjD