### PR TITLE
Fix: Add @types/node and typescript to packages/core devDependencies

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,5 +15,8 @@
   "dependencies": {
     "stripe": "^14.9.0"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "@types/node": "^20.10.0",
+    "typescript": "^5.3.3"
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,13 +44,13 @@ importers:
 
   examples/advanced-pricing:
     dependencies:
-      '@fillet/cli':
+      '@pricectl/cli':
         specifier: workspace:*
         version: link:../../packages/cli
-      '@fillet/constructs':
+      '@pricectl/constructs':
         specifier: workspace:*
         version: link:../../packages/constructs
-      '@fillet/core':
+      '@pricectl/core':
         specifier: workspace:*
         version: link:../../packages/core
     devDependencies:
@@ -63,13 +63,13 @@ importers:
 
   examples/basic-subscription:
     dependencies:
-      '@fillet/cli':
+      '@pricectl/cli':
         specifier: workspace:*
         version: link:../../packages/cli
-      '@fillet/constructs':
+      '@pricectl/constructs':
         specifier: workspace:*
         version: link:../../packages/constructs
-      '@fillet/core':
+      '@pricectl/core':
         specifier: workspace:*
         version: link:../../packages/core
     devDependencies:
@@ -82,18 +82,18 @@ importers:
 
   packages/cli:
     dependencies:
-      '@fillet/constructs':
-        specifier: workspace:*
-        version: link:../constructs
-      '@fillet/core':
-        specifier: workspace:*
-        version: link:../core
       '@oclif/core':
         specifier: ^3.15.0
         version: 3.27.0
       '@oclif/plugin-help':
         specifier: ^6.0.9
         version: 6.2.36
+      '@pricectl/constructs':
+        specifier: workspace:*
+        version: link:../constructs
+      '@pricectl/core':
+        specifier: workspace:*
+        version: link:../core
       chalk:
         specifier: ^4.1.2
         version: 4.1.2
@@ -116,7 +116,7 @@ importers:
 
   packages/constructs:
     dependencies:
-      '@fillet/core':
+      '@pricectl/core':
         specifier: workspace:*
         version: link:../core
       stripe:
@@ -128,6 +128,13 @@ importers:
       stripe:
         specifier: ^14.9.0
         version: 14.25.0
+    devDependencies:
+      '@types/node':
+        specifier: ^20.10.0
+        version: 20.19.25
+      typescript:
+        specifier: ^5.3.3
+        version: 5.9.3
 
 packages:
 


### PR DESCRIPTION
Resolves TypeScript build error where 'process' type was not available
in packages/core. The package uses process.env.STRIPE_SECRET_KEY but
was missing @types/node in its devDependencies. With pnpm's strict
mode enabled, type definitions from the root package.json are not
hoisted, so each package that needs them must declare them explicitly.

https://claude.ai/code/session_01UMHSfk4QoQWyx91Q7UrxjN