### PR TITLE
test: add comprehensive unit tests for core, constructs, and cli packages

### DIFF
--- a/packages/cli/jest.config.js
+++ b/packages/cli/jest.config.js
@@ -4,4 +4,11 @@ module.exports = {
   ...baseConfig,
   displayName: 'cli',
   rootDir: '.',
+  moduleNameMapper: {
+    '^@pricectl/core$': '<rootDir>/../core/src',
+    '^@pricectl/constructs$': '<rootDir>/../constructs/src',
+  },
+  transform: {
+    '^.+\\.ts$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.test.json' }],
+  },
 };

--- a/packages/cli/src/__tests__/deployer.test.ts
+++ b/packages/cli/src/__tests__/deployer.test.ts
@@ -1,0 +1,646 @@
+import { StackManifest } from '@pricectl/core';
+import { StripeDeployer } from '../engine/deployer';
+
+// Stripe SDKのモック
+jest.mock('stripe', () => {
+  return jest.fn().mockImplementation(() => mockStripeInstance);
+});
+
+// モック用のStripeインスタンス
+const mockStripeInstance = {
+  products: {
+    create: jest.fn(),
+    update: jest.fn(),
+    del: jest.fn(),
+    search: jest.fn(),
+  },
+  prices: {
+    create: jest.fn(),
+    update: jest.fn(),
+    search: jest.fn(),
+  },
+  coupons: {
+    create: jest.fn(),
+    retrieve: jest.fn(),
+    del: jest.fn(),
+  },
+};
+
+function resetMocks() {
+  Object.values(mockStripeInstance).forEach(resource => {
+    Object.values(resource).forEach(fn => {
+      (fn as jest.Mock).mockReset();
+    });
+  });
+}
+
+describe('StripeDeployer', () => {
+  let deployer: StripeDeployer;
+
+  beforeEach(() => {
+    resetMocks();
+    deployer = new StripeDeployer('sk_test_dummy');
+  });
+
+  describe('deploy', () => {
+    describe('Product', () => {
+      it('新規Productを作成する', async () => {
+        mockStripeInstance.products.search.mockResolvedValue({ data: [] });
+        mockStripeInstance.products.create.mockResolvedValue({
+          id: 'prod_new_123',
+        });
+
+        const manifest: StackManifest = {
+          stackId: 'TestStack',
+          tags: {},
+          resources: [
+            {
+              id: 'MyProduct',
+              path: 'TestStack/MyProduct',
+              type: 'Stripe::Product',
+              properties: { name: 'Widget', active: true },
+            },
+          ],
+        };
+
+        const result = await deployer.deploy(manifest);
+
+        expect(result.deployed).toHaveLength(1);
+        expect(result.deployed[0]).toEqual({
+          id: 'MyProduct',
+          type: 'Stripe::Product',
+          physicalId: 'prod_new_123',
+          status: 'created',
+        });
+        expect(result.errors).toHaveLength(0);
+
+        // pricectl_idメタデータが付与されることを確認
+        expect(mockStripeInstance.products.create).toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: 'Widget',
+            active: true,
+            metadata: expect.objectContaining({
+              pricectl_id: 'MyProduct',
+              pricectl_path: 'TestStack/MyProduct',
+            }),
+          })
+        );
+      });
+
+      it('既存Productを更新する', async () => {
+        mockStripeInstance.products.search.mockResolvedValue({
+          data: [{ id: 'prod_existing_456' }],
+        });
+        mockStripeInstance.products.update.mockResolvedValue({
+          id: 'prod_existing_456',
+        });
+
+        const manifest: StackManifest = {
+          stackId: 'TestStack',
+          tags: {},
+          resources: [
+            {
+              id: 'MyProduct',
+              path: 'TestStack/MyProduct',
+              type: 'Stripe::Product',
+              properties: { name: 'Updated Widget', active: true },
+            },
+          ],
+        };
+
+        const result = await deployer.deploy(manifest);
+
+        expect(result.deployed).toHaveLength(1);
+        expect(result.deployed[0].status).toBe('updated');
+        expect(result.deployed[0].physicalId).toBe('prod_existing_456');
+
+        expect(mockStripeInstance.products.update).toHaveBeenCalledWith(
+          'prod_existing_456',
+          { name: 'Updated Widget', active: true }
+        );
+      });
+    });
+
+    describe('Price', () => {
+      it('新規Priceを作成する', async () => {
+        mockStripeInstance.prices.search.mockResolvedValue({ data: [] });
+        mockStripeInstance.prices.create.mockResolvedValue({
+          id: 'price_new_789',
+        });
+
+        const manifest: StackManifest = {
+          stackId: 'TestStack',
+          tags: {},
+          resources: [
+            {
+              id: 'MonthlyPrice',
+              path: 'TestStack/MonthlyPrice',
+              type: 'Stripe::Price',
+              properties: {
+                product: 'prod_123',
+                currency: 'usd',
+                unit_amount: 999,
+                active: true,
+              },
+            },
+          ],
+        };
+
+        const result = await deployer.deploy(manifest);
+
+        expect(result.deployed).toHaveLength(1);
+        expect(result.deployed[0]).toEqual({
+          id: 'MonthlyPrice',
+          type: 'Stripe::Price',
+          physicalId: 'price_new_789',
+          status: 'created',
+        });
+      });
+
+      it('変更なしのPriceはunchangedになる', async () => {
+        const existingPrice = {
+          id: 'price_existing',
+          currency: 'usd',
+          unit_amount: 999,
+          unit_amount_decimal: undefined,
+          active: true,
+          nickname: undefined,
+          recurring: null,
+          tiers_mode: undefined,
+          tiers: null,
+          transform_quantity: null,
+          lookup_key: undefined,
+        };
+
+        mockStripeInstance.prices.search.mockResolvedValue({
+          data: [existingPrice],
+        });
+
+        const manifest: StackManifest = {
+          stackId: 'TestStack',
+          tags: {},
+          resources: [
+            {
+              id: 'MyPrice',
+              path: 'TestStack/MyPrice',
+              type: 'Stripe::Price',
+              properties: {
+                product: 'prod_123',
+                currency: 'usd',
+                unit_amount: 999,
+                active: true,
+              },
+            },
+          ],
+        };
+
+        const result = await deployer.deploy(manifest);
+
+        expect(result.deployed).toHaveLength(1);
+        expect(result.deployed[0].status).toBe('unchanged');
+        expect(result.deployed[0].physicalId).toBe('price_existing');
+      });
+
+      it('変更ありのPriceは旧Priceを無効化して新規作成する', async () => {
+        const existingPrice = {
+          id: 'price_old',
+          currency: 'usd',
+          unit_amount: 500,
+          unit_amount_decimal: undefined,
+          active: true,
+          nickname: undefined,
+          recurring: null,
+          tiers_mode: undefined,
+          tiers: null,
+          transform_quantity: null,
+          lookup_key: undefined,
+        };
+
+        mockStripeInstance.prices.search.mockResolvedValue({
+          data: [existingPrice],
+        });
+        mockStripeInstance.prices.update.mockResolvedValue({});
+        mockStripeInstance.prices.create.mockResolvedValue({
+          id: 'price_new',
+        });
+
+        const manifest: StackManifest = {
+          stackId: 'TestStack',
+          tags: {},
+          resources: [
+            {
+              id: 'MyPrice',
+              path: 'TestStack/MyPrice',
+              type: 'Stripe::Price',
+              properties: {
+                product: 'prod_123',
+                currency: 'usd',
+                unit_amount: 999, // 変更
+                active: true,
+              },
+            },
+          ],
+        };
+
+        const result = await deployer.deploy(manifest);
+
+        expect(result.deployed[0].status).toBe('created');
+        expect(result.deployed[0].physicalId).toBe('price_new');
+
+        // 旧Priceが無効化されたことを確認
+        expect(mockStripeInstance.prices.update).toHaveBeenCalledWith(
+          'price_old',
+          { active: false }
+        );
+      });
+    });
+
+    describe('Coupon', () => {
+      it('新規Couponを作成する（resource_missingエラー時）', async () => {
+        const notFoundError = new Error('No such coupon');
+        (notFoundError as any).code = 'resource_missing';
+        mockStripeInstance.coupons.retrieve.mockRejectedValue(notFoundError);
+        mockStripeInstance.coupons.create.mockResolvedValue({
+          id: 'SUMMER20',
+        });
+
+        const manifest: StackManifest = {
+          stackId: 'TestStack',
+          tags: {},
+          resources: [
+            {
+              id: 'SUMMER20',
+              path: 'TestStack/SUMMER20',
+              type: 'Stripe::Coupon',
+              properties: {
+                duration: 'once',
+                percent_off: 20,
+              },
+            },
+          ],
+        };
+
+        const result = await deployer.deploy(manifest);
+
+        expect(result.deployed).toHaveLength(1);
+        expect(result.deployed[0]).toEqual({
+          id: 'SUMMER20',
+          type: 'Stripe::Coupon',
+          physicalId: 'SUMMER20',
+          status: 'created',
+        });
+      });
+
+      it('既存Couponが見つかった場合はunchanged', async () => {
+        mockStripeInstance.coupons.retrieve.mockResolvedValue({
+          id: 'EXISTING',
+        });
+
+        const manifest: StackManifest = {
+          stackId: 'TestStack',
+          tags: {},
+          resources: [
+            {
+              id: 'EXISTING',
+              path: 'TestStack/EXISTING',
+              type: 'Stripe::Coupon',
+              properties: { duration: 'once', percent_off: 10 },
+            },
+          ],
+        };
+
+        const result = await deployer.deploy(manifest);
+
+        expect(result.deployed[0].status).toBe('unchanged');
+      });
+    });
+
+    describe('依存関係の解決', () => {
+      it('Productの物理IDがPriceのproductプロパティに反映される', async () => {
+        // Product: 新規作成
+        mockStripeInstance.products.search.mockResolvedValue({ data: [] });
+        mockStripeInstance.products.create.mockResolvedValue({
+          id: 'prod_resolved_abc',
+        });
+
+        // Price: 新規作成
+        mockStripeInstance.prices.search.mockResolvedValue({ data: [] });
+        mockStripeInstance.prices.create.mockResolvedValue({
+          id: 'price_created_xyz',
+        });
+
+        const manifest: StackManifest = {
+          stackId: 'TestStack',
+          tags: {},
+          resources: [
+            {
+              id: 'MyProduct',
+              path: 'TestStack/MyProduct',
+              type: 'Stripe::Product',
+              properties: { name: 'Widget', active: true },
+            },
+            {
+              id: 'MyPrice',
+              path: 'TestStack/MyPrice',
+              type: 'Stripe::Price',
+              properties: {
+                product: 'MyProduct', // 論理ID
+                currency: 'usd',
+                unit_amount: 1000,
+                active: true,
+              },
+            },
+          ],
+        };
+
+        const result = await deployer.deploy(manifest);
+
+        expect(result.deployed).toHaveLength(2);
+
+        // PriceのcreateでproductがphysicalId（prod_resolved_abc）に解決されている
+        expect(mockStripeInstance.prices.create).toHaveBeenCalledWith(
+          expect.objectContaining({
+            product: 'prod_resolved_abc',
+          })
+        );
+      });
+    });
+
+    describe('エラーハンドリング', () => {
+      it('デプロイ中のエラーがerrors配列に記録される', async () => {
+        mockStripeInstance.products.search.mockRejectedValue(
+          new Error('Network failure')
+        );
+
+        const manifest: StackManifest = {
+          stackId: 'TestStack',
+          tags: {},
+          resources: [
+            {
+              id: 'BadProduct',
+              path: 'TestStack/BadProduct',
+              type: 'Stripe::Product',
+              properties: { name: 'Widget' },
+            },
+          ],
+        };
+
+        const result = await deployer.deploy(manifest);
+
+        expect(result.deployed).toHaveLength(0);
+        expect(result.errors).toHaveLength(1);
+        expect(result.errors[0]).toEqual({
+          id: 'BadProduct',
+          type: 'Stripe::Product',
+          error: 'Network failure',
+        });
+      });
+
+      it('未知のリソースタイプはエラーになる', async () => {
+        const manifest: StackManifest = {
+          stackId: 'TestStack',
+          tags: {},
+          resources: [
+            {
+              id: 'Unknown',
+              path: 'TestStack/Unknown',
+              type: 'Stripe::Unknown',
+              properties: {},
+            },
+          ],
+        };
+
+        const result = await deployer.deploy(manifest);
+
+        expect(result.errors).toHaveLength(1);
+        expect(result.errors[0].error).toContain('Unknown resource type');
+      });
+    });
+  });
+
+  describe('destroy', () => {
+    it('Productを削除する', async () => {
+      mockStripeInstance.products.search.mockResolvedValue({
+        data: [{ id: 'prod_to_delete' }],
+      });
+      mockStripeInstance.products.del.mockResolvedValue({});
+
+      const manifest: StackManifest = {
+        stackId: 'TestStack',
+        tags: {},
+        resources: [
+          {
+            id: 'MyProduct',
+            path: 'TestStack/MyProduct',
+            type: 'Stripe::Product',
+            properties: { name: 'Widget' },
+          },
+        ],
+      };
+
+      const result = await deployer.destroy(manifest);
+
+      expect(result.destroyed).toHaveLength(1);
+      expect(result.destroyed[0]).toEqual({
+        id: 'MyProduct',
+        type: 'Stripe::Product',
+        status: 'deleted',
+      });
+      expect(mockStripeInstance.products.del).toHaveBeenCalledWith('prod_to_delete');
+    });
+
+    it('Priceを無効化する（Stripeでは削除不可）', async () => {
+      mockStripeInstance.prices.search.mockResolvedValue({
+        data: [{ id: 'price_to_deactivate' }],
+      });
+      mockStripeInstance.prices.update.mockResolvedValue({});
+
+      const manifest: StackManifest = {
+        stackId: 'TestStack',
+        tags: {},
+        resources: [
+          {
+            id: 'MyPrice',
+            path: 'TestStack/MyPrice',
+            type: 'Stripe::Price',
+            properties: { product: 'prod_123', currency: 'usd' },
+          },
+        ],
+      };
+
+      const result = await deployer.destroy(manifest);
+
+      expect(result.destroyed).toHaveLength(1);
+      expect(result.destroyed[0].status).toBe('deactivated');
+      expect(mockStripeInstance.prices.update).toHaveBeenCalledWith(
+        'price_to_deactivate',
+        { active: false }
+      );
+    });
+
+    it('Couponを削除する', async () => {
+      mockStripeInstance.coupons.del.mockResolvedValue({});
+
+      const manifest: StackManifest = {
+        stackId: 'TestStack',
+        tags: {},
+        resources: [
+          {
+            id: 'COUPON1',
+            path: 'TestStack/COUPON1',
+            type: 'Stripe::Coupon',
+            properties: { duration: 'once' },
+          },
+        ],
+      };
+
+      const result = await deployer.destroy(manifest);
+
+      expect(result.destroyed).toHaveLength(1);
+      expect(result.destroyed[0]).toEqual({
+        id: 'COUPON1',
+        type: 'Stripe::Coupon',
+        status: 'deleted',
+      });
+    });
+
+    it('存在しないCouponの削除はスキップされる', async () => {
+      const notFoundError = new Error('No such coupon');
+      (notFoundError as any).code = 'resource_missing';
+      mockStripeInstance.coupons.del.mockRejectedValue(notFoundError);
+
+      const manifest: StackManifest = {
+        stackId: 'TestStack',
+        tags: {},
+        resources: [
+          {
+            id: 'GONE',
+            path: 'TestStack/GONE',
+            type: 'Stripe::Coupon',
+            properties: { duration: 'once' },
+          },
+        ],
+      };
+
+      const result = await deployer.destroy(manifest);
+
+      expect(result.destroyed).toHaveLength(0);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('リソースが逆順で削除される', async () => {
+      // 依存関係: Product → Price の順で定義、破壊は逆順
+      mockStripeInstance.prices.search.mockResolvedValue({
+        data: [{ id: 'price_1' }],
+      });
+      mockStripeInstance.prices.update.mockResolvedValue({});
+      mockStripeInstance.products.search.mockResolvedValue({
+        data: [{ id: 'prod_1' }],
+      });
+      mockStripeInstance.products.del.mockResolvedValue({});
+
+      const manifest: StackManifest = {
+        stackId: 'TestStack',
+        tags: {},
+        resources: [
+          {
+            id: 'MyProduct',
+            path: 'TestStack/MyProduct',
+            type: 'Stripe::Product',
+            properties: { name: 'Widget' },
+          },
+          {
+            id: 'MyPrice',
+            path: 'TestStack/MyPrice',
+            type: 'Stripe::Price',
+            properties: { product: 'prod_1', currency: 'usd' },
+          },
+        ],
+      };
+
+      const result = await deployer.destroy(manifest);
+
+      expect(result.destroyed).toHaveLength(2);
+      // Priceが先に処理される（逆順）
+      expect(result.destroyed[0].id).toBe('MyPrice');
+      expect(result.destroyed[1].id).toBe('MyProduct');
+    });
+
+    it('destroy中のエラーがerrors配列に記録される', async () => {
+      mockStripeInstance.products.search.mockRejectedValue(
+        new Error('API Error')
+      );
+
+      const manifest: StackManifest = {
+        stackId: 'TestStack',
+        tags: {},
+        resources: [
+          {
+            id: 'BadProduct',
+            path: 'TestStack/BadProduct',
+            type: 'Stripe::Product',
+            properties: { name: 'Widget' },
+          },
+        ],
+      };
+
+      const result = await deployer.destroy(manifest);
+
+      expect(result.destroyed).toHaveLength(0);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].error).toBe('API Error');
+    });
+  });
+
+  describe('search queryのエスケープ', () => {
+    it('論理IDにダブルクォートが含まれる場合にエスケープされる', async () => {
+      mockStripeInstance.products.search.mockResolvedValue({ data: [] });
+      mockStripeInstance.products.create.mockResolvedValue({ id: 'prod_1' });
+
+      const manifest: StackManifest = {
+        stackId: 'TestStack',
+        tags: {},
+        resources: [
+          {
+            id: 'Product"WithQuotes',
+            path: 'TestStack/Product"WithQuotes',
+            type: 'Stripe::Product',
+            properties: { name: 'Test' },
+          },
+        ],
+      };
+
+      await deployer.deploy(manifest);
+
+      expect(mockStripeInstance.products.search).toHaveBeenCalledWith({
+        query: expect.stringContaining('Product\\"WithQuotes'),
+        limit: 1,
+      });
+    });
+
+    it('論理IDにバックスラッシュが含まれる場合にエスケープされる', async () => {
+      mockStripeInstance.products.search.mockResolvedValue({ data: [] });
+      mockStripeInstance.products.create.mockResolvedValue({ id: 'prod_1' });
+
+      const manifest: StackManifest = {
+        stackId: 'TestStack',
+        tags: {},
+        resources: [
+          {
+            id: 'Product\\Path',
+            path: 'TestStack/Product\\Path',
+            type: 'Stripe::Product',
+            properties: { name: 'Test' },
+          },
+        ],
+      };
+
+      await deployer.deploy(manifest);
+
+      expect(mockStripeInstance.products.search).toHaveBeenCalledWith({
+        query: expect.stringContaining('Product\\\\Path'),
+        limit: 1,
+      });
+    });
+  });
+});

--- a/packages/cli/tsconfig.test.json
+++ b/packages/cli/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "paths": {
+      "@pricectl/core": ["../core/src"],
+      "@pricectl/constructs": ["../constructs/src"]
+    }
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/constructs/jest.config.js
+++ b/packages/constructs/jest.config.js
@@ -4,4 +4,10 @@ module.exports = {
   ...baseConfig,
   displayName: 'constructs',
   rootDir: '.',
+  moduleNameMapper: {
+    '^@pricectl/core$': '<rootDir>/../core/src',
+  },
+  transform: {
+    '^.+\\.ts$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.test.json' }],
+  },
 };

--- a/packages/constructs/src/__tests__/coupon.test.ts
+++ b/packages/constructs/src/__tests__/coupon.test.ts
@@ -1,0 +1,227 @@
+import { Stack } from '@pricectl/core';
+import { Coupon } from '../coupon';
+
+describe('Coupon', () => {
+  const API_KEY = 'sk_test_dummy_key_for_testing';
+
+  function createStack(id = 'TestStack'): Stack {
+    return new Stack(undefined, id, { apiKey: API_KEY });
+  }
+
+  describe('バリデーション', () => {
+    it('amountOffとpercentOffの両方が指定された場合はエラー', () => {
+      const stack = createStack();
+
+      expect(
+        () =>
+          new Coupon(stack, 'Bad', {
+            duration: 'once',
+            amountOff: 500,
+            percentOff: 10,
+            currency: 'usd',
+          })
+      ).toThrow('Exactly one of amountOff or percentOff must be specified');
+    });
+
+    it('amountOffもpercentOffも指定されていない場合はエラー', () => {
+      const stack = createStack();
+
+      expect(
+        () =>
+          new Coupon(stack, 'Bad', {
+            duration: 'once',
+          })
+      ).toThrow('Exactly one of amountOff or percentOff must be specified');
+    });
+
+    it('duration=repeatingでdurationInMonthsが未指定の場合はエラー', () => {
+      const stack = createStack();
+
+      expect(
+        () =>
+          new Coupon(stack, 'Bad', {
+            duration: 'repeating',
+            percentOff: 10,
+          })
+      ).toThrow('durationInMonths is required when duration is "repeating"');
+    });
+
+    it('amountOff指定時にcurrencyが未指定の場合はエラー', () => {
+      const stack = createStack();
+
+      expect(
+        () =>
+          new Coupon(stack, 'Bad', {
+            duration: 'once',
+            amountOff: 500,
+          })
+      ).toThrow('currency is required when amountOff is specified');
+    });
+  });
+
+  describe('正常な生成', () => {
+    it('percentOffでonce couponを生成できる', () => {
+      const stack = createStack();
+      const coupon = new Coupon(stack, 'Sale', {
+        duration: 'once',
+        percentOff: 20,
+      });
+
+      expect(coupon.duration).toBe('once');
+      expect(coupon.percentOff).toBe(20);
+      expect(coupon.amountOff).toBeUndefined();
+    });
+
+    it('amountOffでforever couponを生成できる', () => {
+      const stack = createStack();
+      const coupon = new Coupon(stack, 'Discount', {
+        duration: 'forever',
+        amountOff: 500,
+        currency: 'usd',
+      });
+
+      expect(coupon.duration).toBe('forever');
+      expect(coupon.amountOff).toBe(500);
+      expect(coupon.currency).toBe('usd');
+    });
+
+    it('repeating couponを生成できる', () => {
+      const stack = createStack();
+      const coupon = new Coupon(stack, 'Promo', {
+        duration: 'repeating',
+        percentOff: 15,
+        durationInMonths: 3,
+      });
+
+      expect(coupon.duration).toBe('repeating');
+      expect(coupon.durationInMonths).toBe(3);
+    });
+
+    it('すべてのオプショナルプロパティを設定できる', () => {
+      const stack = createStack();
+      const coupon = new Coupon(stack, 'FullCoupon', {
+        duration: 'repeating',
+        percentOff: 25,
+        durationInMonths: 6,
+        maxRedemptions: 100,
+        metadata: { campaign: 'summer' },
+        name: 'Summer Sale',
+        redeemBy: 1735689600,
+        appliesTo: { products: ['prod_123'] },
+      });
+
+      expect(coupon.maxRedemptions).toBe(100);
+      expect(coupon.metadata).toEqual({ campaign: 'summer' });
+      expect(coupon.name).toBe('Summer Sale');
+      expect(coupon.redeemBy).toBe(1735689600);
+      expect(coupon.appliesTo).toEqual({ products: ['prod_123'] });
+    });
+  });
+
+  describe('synthesizeProperties（synth経由）', () => {
+    it('percentOff couponのpropertiesが正しい', () => {
+      const stack = createStack();
+      new Coupon(stack, 'Sale', {
+        duration: 'once',
+        percentOff: 20,
+        name: 'Flash Sale',
+      });
+
+      const manifest = stack.synth();
+      const props = manifest.resources[0].properties;
+
+      expect(props.duration).toBe('once');
+      expect(props.percent_off).toBe(20);
+      expect(props.name).toBe('Flash Sale');
+      expect(props).not.toHaveProperty('amount_off');
+      expect(props).not.toHaveProperty('currency');
+    });
+
+    it('amountOff couponのpropertiesが正しい', () => {
+      const stack = createStack();
+      new Coupon(stack, 'Discount', {
+        duration: 'forever',
+        amountOff: 1000,
+        currency: 'jpy',
+      });
+
+      const manifest = stack.synth();
+      const props = manifest.resources[0].properties;
+
+      expect(props.duration).toBe('forever');
+      expect(props.amount_off).toBe(1000);
+      expect(props.currency).toBe('jpy');
+      expect(props).not.toHaveProperty('percent_off');
+    });
+
+    it('repeating couponでduration_in_monthsが含まれる', () => {
+      const stack = createStack();
+      new Coupon(stack, 'Promo', {
+        duration: 'repeating',
+        percentOff: 10,
+        durationInMonths: 12,
+      });
+
+      const manifest = stack.synth();
+      const props = manifest.resources[0].properties;
+
+      expect(props.duration_in_months).toBe(12);
+    });
+
+    it('すべてのオプショナルプロパティがsnake_caseで含まれる', () => {
+      const stack = createStack();
+      new Coupon(stack, 'Full', {
+        duration: 'once',
+        percentOff: 50,
+        maxRedemptions: 200,
+        metadata: { source: 'api' },
+        name: 'Big Sale',
+        redeemBy: 1735689600,
+        appliesTo: { products: ['prod_abc'] },
+      });
+
+      const manifest = stack.synth();
+      const props = manifest.resources[0].properties;
+
+      expect(props.max_redemptions).toBe(200);
+      expect(props.metadata).toEqual({ source: 'api' });
+      expect(props.name).toBe('Big Sale');
+      expect(props.redeem_by).toBe(1735689600);
+      expect(props.applies_to).toEqual({ products: ['prod_abc'] });
+    });
+
+    it('未指定のオプショナルプロパティはpropertiesに含まれない', () => {
+      const stack = createStack();
+      new Coupon(stack, 'Minimal', {
+        duration: 'once',
+        percentOff: 5,
+      });
+
+      const manifest = stack.synth();
+      const props = manifest.resources[0].properties;
+
+      expect(props).not.toHaveProperty('amount_off');
+      expect(props).not.toHaveProperty('currency');
+      expect(props).not.toHaveProperty('duration_in_months');
+      expect(props).not.toHaveProperty('max_redemptions');
+      expect(props).not.toHaveProperty('metadata');
+      expect(props).not.toHaveProperty('name');
+      expect(props).not.toHaveProperty('redeem_by');
+      expect(props).not.toHaveProperty('applies_to');
+    });
+  });
+
+  describe('resourceType', () => {
+    it('Stripe::Couponを返す', () => {
+      const stack = createStack();
+      new Coupon(stack, 'MyCoupon', {
+        duration: 'once',
+        percentOff: 10,
+      });
+
+      const manifest = stack.synth();
+
+      expect(manifest.resources[0].type).toBe('Stripe::Coupon');
+    });
+  });
+});

--- a/packages/constructs/src/__tests__/price.test.ts
+++ b/packages/constructs/src/__tests__/price.test.ts
@@ -1,0 +1,223 @@
+import { Stack } from '@pricectl/core';
+import { Product } from '../product';
+import { Price } from '../price';
+
+describe('Price', () => {
+  const API_KEY = 'sk_test_dummy_key_for_testing';
+
+  function createStack(id = 'TestStack'): Stack {
+    return new Stack(undefined, id, { apiKey: API_KEY });
+  }
+
+  describe('基本的なPrice', () => {
+    it('必須プロパティのみで生成できる', () => {
+      const stack = createStack();
+      const product = new Product(stack, 'Prod', { name: 'Widget' });
+      const price = new Price(stack, 'MyPrice', {
+        product,
+        currency: 'usd',
+      });
+
+      expect(price.product).toBe(product);
+      expect(price.currency).toBe('usd');
+      expect(price.active).toBe(true); // デフォルト値
+    });
+
+    it('unitAmountを設定できる', () => {
+      const stack = createStack();
+      const product = new Product(stack, 'Prod', { name: 'Widget' });
+      const price = new Price(stack, 'MyPrice', {
+        product,
+        currency: 'usd',
+        unitAmount: 1999,
+      });
+
+      expect(price.unitAmount).toBe(1999);
+    });
+
+    it('文字列でproductを参照できる', () => {
+      const stack = createStack();
+      const price = new Price(stack, 'MyPrice', {
+        product: 'prod_existing123',
+        currency: 'jpy',
+      });
+
+      expect(price.product).toBe('prod_existing123');
+    });
+  });
+
+  describe('synthesizeProperties（synth経由）', () => {
+    it('Productオブジェクト参照時にidが使われる', () => {
+      const stack = createStack();
+      const product = new Product(stack, 'Prod', { name: 'Widget' });
+      new Price(stack, 'MyPrice', {
+        product,
+        currency: 'usd',
+        unitAmount: 1000,
+      });
+
+      const manifest = stack.synth();
+      const priceResource = manifest.resources.find(r => r.id === 'MyPrice')!;
+
+      // physicalIdがないのでnode.idがfallback
+      expect(priceResource.properties.product).toBe('Prod');
+      expect(priceResource.properties.currency).toBe('usd');
+      expect(priceResource.properties.unit_amount).toBe(1000);
+      expect(priceResource.properties.active).toBe(true);
+    });
+
+    it('physicalIdがあるProductの場合はphysicalIdが使われる', () => {
+      const stack = createStack();
+      const product = new Product(stack, 'Prod', {
+        name: 'Widget',
+        physicalId: 'prod_stripe_123',
+      });
+      new Price(stack, 'MyPrice', {
+        product,
+        currency: 'usd',
+      });
+
+      const manifest = stack.synth();
+      const priceResource = manifest.resources.find(r => r.id === 'MyPrice')!;
+
+      expect(priceResource.properties.product).toBe('prod_stripe_123');
+    });
+
+    it('文字列productの場合はそのまま使われる', () => {
+      const stack = createStack();
+      new Price(stack, 'MyPrice', {
+        product: 'prod_existing',
+        currency: 'usd',
+      });
+
+      const manifest = stack.synth();
+      const priceResource = manifest.resources.find(r => r.id === 'MyPrice')!;
+
+      expect(priceResource.properties.product).toBe('prod_existing');
+    });
+
+    it('recurringプロパティがsnake_caseに変換される', () => {
+      const stack = createStack();
+      new Price(stack, 'MonthlyPrice', {
+        product: 'prod_123',
+        currency: 'usd',
+        unitAmount: 999,
+        recurring: {
+          interval: 'month',
+          intervalCount: 1,
+          usageType: 'licensed',
+          trialPeriodDays: 14,
+        },
+      });
+
+      const manifest = stack.synth();
+      const props = manifest.resources.find(r => r.id === 'MonthlyPrice')!.properties;
+
+      expect(props.recurring).toEqual({
+        interval: 'month',
+        interval_count: 1,
+        usage_type: 'licensed',
+        trial_period_days: 14,
+      });
+    });
+
+    it('tiersが設定された場合にbilling_schemeがtieredになる', () => {
+      const stack = createStack();
+      new Price(stack, 'TieredPrice', {
+        product: 'prod_123',
+        currency: 'usd',
+        tiersMode: 'graduated',
+        tiers: [
+          { upTo: 10, unitAmount: 1000 },
+          { upTo: 'inf', unitAmount: 800 },
+        ],
+      });
+
+      const manifest = stack.synth();
+      const props = manifest.resources.find(r => r.id === 'TieredPrice')!.properties;
+
+      expect(props.billing_scheme).toBe('tiered');
+      expect(props.tiers_mode).toBe('graduated');
+      expect(props.tiers).toEqual([
+        { up_to: 10, unit_amount: 1000, flat_amount: undefined },
+        { up_to: 'inf', unit_amount: 800, flat_amount: undefined },
+      ]);
+    });
+
+    it('transformQuantityがsnake_caseに変換される', () => {
+      const stack = createStack();
+      new Price(stack, 'TransformPrice', {
+        product: 'prod_123',
+        currency: 'usd',
+        unitAmount: 500,
+        transformQuantity: {
+          divideBy: 10,
+          round: 'up',
+        },
+      });
+
+      const manifest = stack.synth();
+      const props = manifest.resources.find(r => r.id === 'TransformPrice')!.properties;
+
+      expect(props.transform_quantity).toEqual({
+        divide_by: 10,
+        round: 'up',
+      });
+    });
+
+    it('未指定のオプショナルプロパティはpropertiesに含まれない', () => {
+      const stack = createStack();
+      new Price(stack, 'MinimalPrice', {
+        product: 'prod_123',
+        currency: 'usd',
+      });
+
+      const manifest = stack.synth();
+      const props = manifest.resources.find(r => r.id === 'MinimalPrice')!.properties;
+
+      expect(props).not.toHaveProperty('unit_amount');
+      expect(props).not.toHaveProperty('unit_amount_decimal');
+      expect(props).not.toHaveProperty('nickname');
+      expect(props).not.toHaveProperty('recurring');
+      expect(props).not.toHaveProperty('metadata');
+      expect(props).not.toHaveProperty('lookup_key');
+      expect(props).not.toHaveProperty('tiers');
+      expect(props).not.toHaveProperty('tiers_mode');
+      expect(props).not.toHaveProperty('billing_scheme');
+      expect(props).not.toHaveProperty('transform_quantity');
+    });
+
+    it('nicknameとlookupKeyが含まれる', () => {
+      const stack = createStack();
+      new Price(stack, 'NamedPrice', {
+        product: 'prod_123',
+        currency: 'usd',
+        unitAmount: 1000,
+        nickname: 'Standard Monthly',
+        lookupKey: 'standard_monthly',
+        metadata: { plan: 'standard' },
+      });
+
+      const manifest = stack.synth();
+      const props = manifest.resources.find(r => r.id === 'NamedPrice')!.properties;
+
+      expect(props.nickname).toBe('Standard Monthly');
+      expect(props.lookup_key).toBe('standard_monthly');
+      expect(props.metadata).toEqual({ plan: 'standard' });
+    });
+  });
+
+  describe('resourceType', () => {
+    it('Stripe::Priceを返す', () => {
+      const stack = createStack();
+      new Price(stack, 'MyPrice', {
+        product: 'prod_123',
+        currency: 'usd',
+      });
+
+      const manifest = stack.synth();
+
+      expect(manifest.resources[0].type).toBe('Stripe::Price');
+    });
+  });
+});

--- a/packages/constructs/src/__tests__/product.test.ts
+++ b/packages/constructs/src/__tests__/product.test.ts
@@ -1,0 +1,131 @@
+import { Stack } from '@pricectl/core';
+import { Product } from '../product';
+
+describe('Product', () => {
+  const API_KEY = 'sk_test_dummy_key_for_testing';
+
+  function createStack(id = 'TestStack'): Stack {
+    return new Stack(undefined, id, { apiKey: API_KEY });
+  }
+
+  describe('プロパティの設定', () => {
+    it('必須プロパティのみで生成できる', () => {
+      const stack = createStack();
+      const product = new Product(stack, 'MyProduct', {
+        name: 'Premium Plan',
+      });
+
+      expect(product.name).toBe('Premium Plan');
+      expect(product.active).toBe(true); // デフォルト値
+    });
+
+    it('activeをfalseに設定できる', () => {
+      const stack = createStack();
+      const product = new Product(stack, 'MyProduct', {
+        name: 'Inactive Product',
+        active: false,
+      });
+
+      expect(product.active).toBe(false);
+    });
+
+    it('すべてのオプショナルプロパティを設定できる', () => {
+      const stack = createStack();
+      const product = new Product(stack, 'FullProduct', {
+        name: 'Full Product',
+        active: true,
+        description: 'A full product',
+        images: ['https://example.com/img1.png', 'https://example.com/img2.png'],
+        metadata: { tier: 'premium' },
+        url: 'https://example.com/product',
+        unitLabel: 'seat',
+        statementDescriptor: 'ACME PREMIUM',
+        taxCode: 'txcd_10000000',
+      });
+
+      expect(product.description).toBe('A full product');
+      expect(product.images).toEqual([
+        'https://example.com/img1.png',
+        'https://example.com/img2.png',
+      ]);
+      expect(product.metadata).toEqual({ tier: 'premium' });
+      expect(product.url).toBe('https://example.com/product');
+      expect(product.unitLabel).toBe('seat');
+      expect(product.statementDescriptor).toBe('ACME PREMIUM');
+      expect(product.taxCode).toBe('txcd_10000000');
+    });
+  });
+
+  describe('synthesizeProperties（synth経由）', () => {
+    it('必須プロパティのみの場合', () => {
+      const stack = createStack();
+      new Product(stack, 'Prod', { name: 'Widget' });
+
+      const manifest = stack.synth();
+
+      expect(manifest.resources).toHaveLength(1);
+      expect(manifest.resources[0].type).toBe('Stripe::Product');
+      expect(manifest.resources[0].properties).toEqual({
+        name: 'Widget',
+        active: true,
+      });
+    });
+
+    it('オプショナルプロパティがStripe API形式に変換される', () => {
+      const stack = createStack();
+      new Product(stack, 'Prod', {
+        name: 'Widget',
+        description: 'A widget',
+        unitLabel: 'unit',
+        statementDescriptor: 'WIDGET',
+        taxCode: 'txcd_123',
+        images: ['https://example.com/img.png'],
+        metadata: { key: 'value' },
+        url: 'https://example.com',
+      });
+
+      const manifest = stack.synth();
+      const props = manifest.resources[0].properties;
+
+      expect(props.description).toBe('A widget');
+      expect(props.unit_label).toBe('unit'); // camelCase → snake_case
+      expect(props.statement_descriptor).toBe('WIDGET');
+      expect(props.tax_code).toBe('txcd_123');
+      expect(props.images).toEqual(['https://example.com/img.png']);
+      expect(props.metadata).toEqual({ key: 'value' });
+      expect(props.url).toBe('https://example.com');
+    });
+
+    it('未指定のオプショナルプロパティはpropertiesに含まれない', () => {
+      const stack = createStack();
+      new Product(stack, 'Prod', { name: 'Minimal' });
+
+      const manifest = stack.synth();
+      const props = manifest.resources[0].properties;
+
+      expect(props).not.toHaveProperty('description');
+      expect(props).not.toHaveProperty('images');
+      expect(props).not.toHaveProperty('metadata');
+      expect(props).not.toHaveProperty('url');
+      expect(props).not.toHaveProperty('unit_label');
+      expect(props).not.toHaveProperty('statement_descriptor');
+      expect(props).not.toHaveProperty('tax_code');
+    });
+  });
+
+  describe('Constructツリーとの統合', () => {
+    it('Stackの子として登録される', () => {
+      const stack = createStack();
+      const product = new Product(stack, 'Prod', { name: 'Widget' });
+
+      expect(stack.node.children).toContain(product);
+    });
+
+    it('pathがStack/Productの形式', () => {
+      const stack = createStack();
+      const product = new Product(stack, 'MyProduct', { name: 'Widget' });
+
+      expect(product.node.path).toBe('TestStack/MyProduct');
+    });
+  });
+});

--- a/packages/constructs/tsconfig.test.json
+++ b/packages/constructs/tsconfig.test.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "paths": {
+      "@pricectl/core": ["../core/src"]
+    }
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/core/src/__tests__/construct.test.ts
+++ b/packages/core/src/__tests__/construct.test.ts
@@ -1,0 +1,183 @@
+import { Construct, ConstructNode } from '../construct';
+
+describe('Construct', () => {
+  describe('ルートConstruct（scopeなし）', () => {
+    it('idが設定される', () => {
+      const root = new Construct(undefined, 'Root');
+
+      expect(root.node.id).toBe('Root');
+    });
+
+    it('scopeがundefined', () => {
+      const root = new Construct(undefined, 'Root');
+
+      expect(root.node.scope).toBeUndefined();
+    });
+
+    it('子が空の配列', () => {
+      const root = new Construct(undefined, 'Root');
+
+      expect(root.node.children).toEqual([]);
+    });
+
+    it('パスがid自身', () => {
+      const root = new Construct(undefined, 'Root');
+
+      expect(root.node.path).toBe('Root');
+    });
+  });
+
+  describe('親子関係', () => {
+    it('子が親のchildrenに登録される', () => {
+      const parent = new Construct(undefined, 'Parent');
+      const child = new Construct(parent, 'Child');
+
+      expect(parent.node.children).toHaveLength(1);
+      expect(parent.node.children[0]).toBe(child);
+    });
+
+    it('子のscopeが親を指す', () => {
+      const parent = new Construct(undefined, 'Parent');
+      const child = new Construct(parent, 'Child');
+
+      expect(child.node.scope).toBe(parent);
+    });
+
+    it('複数の子を追加できる', () => {
+      const parent = new Construct(undefined, 'Parent');
+      const child1 = new Construct(parent, 'Child1');
+      const child2 = new Construct(parent, 'Child2');
+
+      expect(parent.node.children).toHaveLength(2);
+      expect(parent.node.children).toContain(child1);
+      expect(parent.node.children).toContain(child2);
+    });
+
+    it('childrenは防御的コピーを返す', () => {
+      const parent = new Construct(undefined, 'Parent');
+      new Construct(parent, 'Child');
+
+      const children = parent.node.children;
+      children.push(new Construct(undefined, 'Intruder'));
+
+      expect(parent.node.children).toHaveLength(1);
+    });
+  });
+
+  describe('path', () => {
+    it('ネストした構造のパスがスラッシュ区切り', () => {
+      const root = new Construct(undefined, 'Root');
+      const mid = new Construct(root, 'Middle');
+      const leaf = new Construct(mid, 'Leaf');
+
+      expect(leaf.node.path).toBe('Root/Middle/Leaf');
+    });
+
+    it('3階層以上でも正しくパスが組み立てられる', () => {
+      const a = new Construct(undefined, 'A');
+      const b = new Construct(a, 'B');
+      const c = new Construct(b, 'C');
+      const d = new Construct(c, 'D');
+
+      expect(d.node.path).toBe('A/B/C/D');
+    });
+  });
+
+  describe('toString', () => {
+    it('pathと同じ文字列を返す', () => {
+      const root = new Construct(undefined, 'Root');
+      const child = new Construct(root, 'Child');
+
+      expect(child.toString()).toBe('Root/Child');
+    });
+  });
+});
+
+describe('ConstructNode', () => {
+  describe('metadata', () => {
+    it('メタデータの追加と取得', () => {
+      const construct = new Construct(undefined, 'Test');
+
+      construct.node.addMetadata('key', 'value');
+
+      expect(construct.node.getMetadata('key')).toBe('value');
+    });
+
+    it('存在しないキーはundefined', () => {
+      const construct = new Construct(undefined, 'Test');
+
+      expect(construct.node.getMetadata('nonexistent')).toBeUndefined();
+    });
+
+    it('オブジェクトをメタデータとして保存できる', () => {
+      const construct = new Construct(undefined, 'Test');
+      const data = { type: 'Product', properties: { name: 'Test' } };
+
+      construct.node.addMetadata('resource', data);
+
+      expect(construct.node.getMetadata('resource')).toEqual(data);
+    });
+
+    it('同一キーで上書きされる', () => {
+      const construct = new Construct(undefined, 'Test');
+
+      construct.node.addMetadata('key', 'first');
+      construct.node.addMetadata('key', 'second');
+
+      expect(construct.node.getMetadata('key')).toBe('second');
+    });
+  });
+
+  describe('findAll', () => {
+    it('自身のみのツリーでは自身だけ返す', () => {
+      const root = new Construct(undefined, 'Root');
+
+      const all = root.node.findAll();
+
+      expect(all).toHaveLength(1);
+      expect(all[0]).toBe(root);
+    });
+
+    it('子を含むすべてのConstructを返す', () => {
+      const root = new Construct(undefined, 'Root');
+      const child1 = new Construct(root, 'Child1');
+      const child2 = new Construct(root, 'Child2');
+
+      const all = root.node.findAll();
+
+      expect(all).toHaveLength(3);
+      expect(all).toContain(root);
+      expect(all).toContain(child1);
+      expect(all).toContain(child2);
+    });
+
+    it('孫まで再帰的に返す', () => {
+      const root = new Construct(undefined, 'Root');
+      const child = new Construct(root, 'Child');
+      const grandchild = new Construct(child, 'Grandchild');
+
+      const all = root.node.findAll();
+
+      expect(all).toHaveLength(3);
+      expect(all).toContain(root);
+      expect(all).toContain(child);
+      expect(all).toContain(grandchild);
+    });
+
+    it('深いツリーでもすべてのノードを返す', () => {
+      const root = new Construct(undefined, 'Root');
+      const a = new Construct(root, 'A');
+      const b = new Construct(root, 'B');
+      const a1 = new Construct(a, 'A1');
+      const a2 = new Construct(a, 'A2');
+      const b1 = new Construct(b, 'B1');
+
+      const all = root.node.findAll();
+
+      expect(all).toHaveLength(6);
+      expect(all).toContain(a1);
+      expect(all).toContain(a2);
+      expect(all).toContain(b1);
+    });
+  });
+});

--- a/packages/core/src/__tests__/resource.test.ts
+++ b/packages/core/src/__tests__/resource.test.ts
@@ -1,0 +1,100 @@
+import { Construct } from '../construct';
+import { Stack } from '../stack';
+import { Resource } from '../resource';
+
+class ConcreteResource extends Resource {
+  private readonly _type: string;
+  private readonly _properties: any;
+
+  constructor(scope: Construct, id: string, type: string, properties: any) {
+    super(scope, id);
+    this._type = type;
+    this._properties = properties;
+    this.registerResourceMetadata();
+  }
+
+  protected get resourceType(): string {
+    return this._type;
+  }
+
+  protected synthesizeProperties(): any {
+    return this._properties;
+  }
+}
+
+describe('Resource', () => {
+  const API_KEY = 'sk_test_dummy_key_for_testing';
+
+  describe('findStack', () => {
+    it('直接の親がStackの場合に取得できる', () => {
+      const stack = new Stack(undefined, 'MyStack', { apiKey: API_KEY });
+      const resource = new ConcreteResource(stack, 'Res', 'Test', {});
+
+      expect(resource.stack).toBe(stack);
+    });
+
+    it('祖先にStackがある場合に取得できる', () => {
+      const stack = new Stack(undefined, 'MyStack', { apiKey: API_KEY });
+      const group = new Construct(stack, 'Group');
+      const resource = new ConcreteResource(group, 'Res', 'Test', {});
+
+      expect(resource.stack).toBe(stack);
+    });
+
+    it('Stackが祖先にない場合はエラー', () => {
+      const root = new Construct(undefined, 'Root');
+
+      expect(
+        () => new ConcreteResource(root, 'Res', 'Test', {})
+      ).toThrow('must be created within a Stack');
+    });
+  });
+
+  describe('physicalId', () => {
+    it('propsで指定したphysicalIdが設定される', () => {
+      const stack = new Stack(undefined, 'MyStack', { apiKey: API_KEY });
+
+      class ResourceWithPhysicalId extends Resource {
+        constructor(scope: Construct, id: string, physicalId: string) {
+          super(scope, id, { physicalId });
+          this.registerResourceMetadata();
+        }
+
+        protected get resourceType(): string {
+          return 'Test';
+        }
+
+        protected synthesizeProperties(): any {
+          return {};
+        }
+      }
+
+      const resource = new ResourceWithPhysicalId(stack, 'Res', 'prod_123');
+
+      expect(resource.physicalId).toBe('prod_123');
+    });
+
+    it('physicalId未指定の場合はundefined', () => {
+      const stack = new Stack(undefined, 'MyStack', { apiKey: API_KEY });
+      const resource = new ConcreteResource(stack, 'Res', 'Test', {});
+
+      expect(resource.physicalId).toBeUndefined();
+    });
+  });
+
+  describe('registerResourceMetadata', () => {
+    it('resourceメタデータが登録される', () => {
+      const stack = new Stack(undefined, 'MyStack', { apiKey: API_KEY });
+      const resource = new ConcreteResource(stack, 'Res', 'Stripe::Product', {
+        name: 'Widget',
+      });
+
+      const metadata = resource.node.getMetadata('resource');
+
+      expect(metadata).toEqual({
+        type: 'Stripe::Product',
+        properties: { name: 'Widget' },
+      });
+    });
+  });
+});

--- a/packages/core/src/__tests__/stack.test.ts
+++ b/packages/core/src/__tests__/stack.test.ts
@@ -1,0 +1,178 @@
+import { Construct } from '../construct';
+import { Stack } from '../stack';
+import { Resource } from '../resource';
+
+// テスト用の具象Resourceクラス
+class TestResource extends Resource {
+  constructor(
+    scope: Construct,
+    id: string,
+    private readonly props: { type: string; properties: any; physicalId?: string }
+  ) {
+    super(scope, id, { physicalId: props.physicalId });
+    this.registerResourceMetadata();
+  }
+
+  protected get resourceType(): string {
+    return this.props.type;
+  }
+
+  protected synthesizeProperties(): any {
+    return this.props.properties;
+  }
+}
+
+describe('Stack', () => {
+  const API_KEY = 'sk_test_dummy_key_for_testing';
+
+  describe('コンストラクタ', () => {
+    it('apiKeyをpropsから受け取れる', () => {
+      const stack = new Stack(undefined, 'TestStack', { apiKey: API_KEY });
+
+      expect(stack.apiKey).toBe(API_KEY);
+    });
+
+    it('descriptionが設定される', () => {
+      const stack = new Stack(undefined, 'TestStack', {
+        apiKey: API_KEY,
+        description: 'A test stack',
+      });
+
+      expect(stack.description).toBe('A test stack');
+    });
+
+    it('tagsが設定される', () => {
+      const stack = new Stack(undefined, 'TestStack', {
+        apiKey: API_KEY,
+        tags: { env: 'test' },
+      });
+
+      expect(stack.tags).toEqual({ env: 'test' });
+    });
+
+    it('tagsのデフォルトは空オブジェクト', () => {
+      const stack = new Stack(undefined, 'TestStack', { apiKey: API_KEY });
+
+      expect(stack.tags).toEqual({});
+    });
+
+    it('環境変数からapiKeyを取得できる', () => {
+      const original = process.env.STRIPE_SECRET_KEY;
+      try {
+        process.env.STRIPE_SECRET_KEY = 'sk_test_from_env';
+        const stack = new Stack(undefined, 'TestStack');
+
+        expect(stack.apiKey).toBe('sk_test_from_env');
+      } finally {
+        if (original !== undefined) {
+          process.env.STRIPE_SECRET_KEY = original;
+        } else {
+          delete process.env.STRIPE_SECRET_KEY;
+        }
+      }
+    });
+
+    it('apiKeyが未指定かつ環境変数もない場合はエラー', () => {
+      const original = process.env.STRIPE_SECRET_KEY;
+      try {
+        delete process.env.STRIPE_SECRET_KEY;
+
+        expect(() => new Stack(undefined, 'TestStack')).toThrow(
+          'Stripe API key is required'
+        );
+      } finally {
+        if (original !== undefined) {
+          process.env.STRIPE_SECRET_KEY = original;
+        }
+      }
+    });
+  });
+
+  describe('synth', () => {
+    it('リソースがない場合は空のmanifestを返す', () => {
+      const stack = new Stack(undefined, 'EmptyStack', { apiKey: API_KEY });
+
+      const manifest = stack.synth();
+
+      expect(manifest.stackId).toBe('EmptyStack');
+      expect(manifest.resources).toEqual([]);
+    });
+
+    it('descriptionとtagsがmanifestに含まれる', () => {
+      const stack = new Stack(undefined, 'MyStack', {
+        apiKey: API_KEY,
+        description: 'Test',
+        tags: { env: 'staging' },
+      });
+
+      const manifest = stack.synth();
+
+      expect(manifest.description).toBe('Test');
+      expect(manifest.tags).toEqual({ env: 'staging' });
+    });
+
+    it('子リソースがmanifestに含まれる', () => {
+      const stack = new Stack(undefined, 'MyStack', { apiKey: API_KEY });
+      new TestResource(stack, 'Product1', {
+        type: 'Stripe::Product',
+        properties: { name: 'Widget' },
+      });
+
+      const manifest = stack.synth();
+
+      expect(manifest.resources).toHaveLength(1);
+      expect(manifest.resources[0]).toEqual({
+        id: 'Product1',
+        path: 'MyStack/Product1',
+        type: 'Stripe::Product',
+        properties: { name: 'Widget' },
+      });
+    });
+
+    it('複数リソースがmanifestに含まれる', () => {
+      const stack = new Stack(undefined, 'MyStack', { apiKey: API_KEY });
+      new TestResource(stack, 'Prod', {
+        type: 'Stripe::Product',
+        properties: { name: 'Widget' },
+      });
+      new TestResource(stack, 'Price', {
+        type: 'Stripe::Price',
+        properties: { currency: 'usd', unit_amount: 1000 },
+      });
+
+      const manifest = stack.synth();
+
+      expect(manifest.resources).toHaveLength(2);
+      expect(manifest.resources.map(r => r.id)).toEqual(['Prod', 'Price']);
+    });
+
+    it('resourceメタデータがないConstructはmanifestに含まれない', () => {
+      const stack = new Stack(undefined, 'MyStack', { apiKey: API_KEY });
+      // 普通のConstructにはresourceメタデータがない
+      new Construct(stack, 'PlainConstruct');
+      new TestResource(stack, 'Prod', {
+        type: 'Stripe::Product',
+        properties: { name: 'Widget' },
+      });
+
+      const manifest = stack.synth();
+
+      expect(manifest.resources).toHaveLength(1);
+      expect(manifest.resources[0].id).toBe('Prod');
+    });
+
+    it('ネストしたリソースもmanifestに含まれる', () => {
+      const stack = new Stack(undefined, 'MyStack', { apiKey: API_KEY });
+      const group = new Construct(stack, 'Group');
+      new TestResource(group, 'NestedProduct', {
+        type: 'Stripe::Product',
+        properties: { name: 'Nested' },
+      });
+
+      const manifest = stack.synth();
+
+      expect(manifest.resources).toHaveLength(1);
+      expect(manifest.resources[0].path).toBe('MyStack/Group/NestedProduct');
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,13 +44,13 @@ importers:
 
   examples/advanced-pricing:
     dependencies:
-      '@fillet/cli':
+      '@pricectl/cli':
         specifier: workspace:*
         version: link:../../packages/cli
-      '@fillet/constructs':
+      '@pricectl/constructs':
         specifier: workspace:*
         version: link:../../packages/constructs
-      '@fillet/core':
+      '@pricectl/core':
         specifier: workspace:*
         version: link:../../packages/core
     devDependencies:
@@ -63,13 +63,13 @@ importers:
 
   examples/basic-subscription:
     dependencies:
-      '@fillet/cli':
+      '@pricectl/cli':
         specifier: workspace:*
         version: link:../../packages/cli
-      '@fillet/constructs':
+      '@pricectl/constructs':
         specifier: workspace:*
         version: link:../../packages/constructs
-      '@fillet/core':
+      '@pricectl/core':
         specifier: workspace:*
         version: link:../../packages/core
     devDependencies:
@@ -82,18 +82,18 @@ importers:
 
   packages/cli:
     dependencies:
-      '@fillet/constructs':
-        specifier: workspace:*
-        version: link:../constructs
-      '@fillet/core':
-        specifier: workspace:*
-        version: link:../core
       '@oclif/core':
         specifier: ^3.15.0
         version: 3.27.0
       '@oclif/plugin-help':
         specifier: ^6.0.9
         version: 6.2.36
+      '@pricectl/constructs':
+        specifier: workspace:*
+        version: link:../constructs
+      '@pricectl/core':
+        specifier: workspace:*
+        version: link:../core
       chalk:
         specifier: ^4.1.2
         version: 4.1.2
@@ -116,7 +116,7 @@ importers:
 
   packages/constructs:
     dependencies:
-      '@fillet/core':
+      '@pricectl/core':
         specifier: workspace:*
         version: link:../core
       stripe:


### PR DESCRIPTION
Add 89 unit tests across all three packages following classical testing
principles (Kent Beck / t_wada style) with real objects and mocks only
at system boundaries (Stripe API).

@pricectl/core (37 tests):
- Construct: tree construction, parent-child, path resolution, findAll
- Stack: constructor validation, env variable fallback, synth()
- Resource: findStack traversal, physicalId, metadata registration

@pricectl/constructs (34 tests):
- Product: property defaults, synthesis, snake_case conversion
- Price: recurring, tiers, transformQuantity, product reference resolution
- Coupon: validation (amountOff XOR percentOff, durationInMonths, currency)

@pricectl/cli (18 tests):
- StripeDeployer: deploy (create/update/unchanged), destroy (delete/deactivate),
  dependency resolution (logical→physical ID), error handling,
  search query escaping

Also configures jest moduleNameMapper and tsconfig paths for cross-package
test imports without requiring a build step.

https://claude.ai/code/session_01TmjDdqPTfCFFu38rUbqaeH