### PR TITLE
Add files field to package.json for npm publishing

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -7,6 +7,10 @@
   "bin": {
     "pricectl": "./bin/run"
   },
+  "files": [
+    "dist",
+    "bin"
+  ],
   "scripts": {
     "build": "tsc",
     "clean": "rimraf dist",

--- a/packages/constructs/package.json
+++ b/packages/constructs/package.json
@@ -4,6 +4,9 @@
   "description": "Stripe pricing resource constructs for pricectl",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc",
     "clean": "rimraf dist",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,6 +4,9 @@
   "description": "Core IaC library for pricectl",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc",
     "clean": "rimraf dist",


### PR DESCRIPTION
- @pricectl/cli: includes dist and bin directories
- @pricectl/core: includes dist directory
- @pricectl/constructs: includes dist directory

This ensures only necessary files are published to npm and reduces package size.

https://claude.ai/code/session_01TRZsuChc5EdMEotRwm9DiB