### PR TITLE
Remove old fillet branding and update to pricectl

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,8 +15,8 @@ Thank you for your interest in contributing to pricectl! This document provides 
 1. Fork the repository
 2. Clone your fork:
    ```bash
-   git clone https://github.com/YOUR_USERNAME/fillet.git
-   cd fillet
+   git clone https://github.com/YOUR_USERNAME/pricectl.git
+   cd pricectl
    ```
 
 3. Install dependencies:

--- a/README.md
+++ b/README.md
@@ -272,8 +272,8 @@ Check out the [examples](./examples) directory for complete working examples:
 
 ```bash
 # Clone the repository
-git clone https://github.com/hideokamoto/fillet.git
-cd fillet
+git clone https://github.com/hideokamoto/pricectl.git
+cd pricectl
 
 # Install dependencies
 pnpm install

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/hideokamoto/fillet.git"
+    "url": "git+https://github.com/hideokamoto/pricectl.git"
   },
   "license": "MIT"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,13 +44,13 @@ importers:
 
   examples/advanced-pricing:
     dependencies:
-      '@fillet/cli':
+      '@pricectl/cli':
         specifier: workspace:*
         version: link:../../packages/cli
-      '@fillet/constructs':
+      '@pricectl/constructs':
         specifier: workspace:*
         version: link:../../packages/constructs
-      '@fillet/core':
+      '@pricectl/core':
         specifier: workspace:*
         version: link:../../packages/core
     devDependencies:
@@ -63,13 +63,13 @@ importers:
 
   examples/basic-subscription:
     dependencies:
-      '@fillet/cli':
+      '@pricectl/cli':
         specifier: workspace:*
         version: link:../../packages/cli
-      '@fillet/constructs':
+      '@pricectl/constructs':
         specifier: workspace:*
         version: link:../../packages/constructs
-      '@fillet/core':
+      '@pricectl/core':
         specifier: workspace:*
         version: link:../../packages/core
     devDependencies:
@@ -82,18 +82,18 @@ importers:
 
   packages/cli:
     dependencies:
-      '@fillet/constructs':
-        specifier: workspace:*
-        version: link:../constructs
-      '@fillet/core':
-        specifier: workspace:*
-        version: link:../core
       '@oclif/core':
         specifier: ^3.15.0
         version: 3.27.0
       '@oclif/plugin-help':
         specifier: ^6.0.9
         version: 6.2.36
+      '@pricectl/constructs':
+        specifier: workspace:*
+        version: link:../constructs
+      '@pricectl/core':
+        specifier: workspace:*
+        version: link:../core
       chalk:
         specifier: ^4.1.2
         version: 4.1.2
@@ -116,7 +116,7 @@ importers:
 
   packages/constructs:
     dependencies:
-      '@fillet/core':
+      '@pricectl/core':
         specifier: workspace:*
         version: link:../core
       stripe:


### PR DESCRIPTION
- Update package.json repository URL from fillet.git to pricectl.git
- Fix git clone URLs in README.md and CONTRIBUTING.md
- Update directory names from 'fillet' to 'pricectl' in documentation
- Regenerate pnpm-lock.yaml with pnpm install

This ensures users can properly clone and set up the project using the correct repository name.

https://claude.ai/code/session_01XrAHpVtiPwui2JqrdVGVdg