### PR TITLE
Remove stripe dependency from core package

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,9 +15,7 @@
   },
   "keywords": ["stripe", "iac", "infrastructure", "cdk"],
   "license": "MIT",
-  "dependencies": {
-    "stripe": "^14.9.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@types/node": "^20.10.0",
     "typescript": "^5.3.3"


### PR DESCRIPTION
## Summary
Removed the `stripe` npm package as a direct dependency from the core package.

## Changes
- Removed `stripe` (^14.9.0) from the dependencies object in `packages/core/package.json`
- Left the dependencies object empty, indicating no direct runtime dependencies are required

## Notes
This change suggests that the stripe functionality may be:
- Moved to a separate package
- Made optional or peer-dependent
- No longer needed in the core package
- Provided through a different mechanism

The core package now has no direct dependencies.

https://claude.ai/code/session_01KRnziZPK5t9TMbjBZGgJ36