### PR TITLE
Add comprehensive README documentation for all packages

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,200 @@
+# @pricectl/cli
+
+Command-line interface for [pricectl](https://github.com/hideokamoto/pricectl) — a kubectl-style tool for managing Stripe pricing resources with TypeScript.
+
+## Installation
+
+```bash
+# Global (recommended for CLI usage)
+npm install -g @pricectl/cli
+# or
+pnpm add -g @pricectl/cli
+```
+
+After installation the `pricectl` binary is available on your `PATH`.
+
+## Quick Start
+
+```bash
+# 1. Create a new project directory
+mkdir my-pricing && cd my-pricing
+
+# 2. Initialise the project (creates pricectl.ts, package.json, tsconfig.json)
+pricectl init
+
+# 3. Set your Stripe secret key
+export STRIPE_SECRET_KEY=sk_test_...
+
+# 4. Install dependencies
+npm install
+
+# 5. Preview changes
+npm run diff
+
+# 6. Deploy to Stripe
+npm run deploy
+```
+
+## Commands
+
+### `pricectl init`
+
+Initialise a new pricectl project in the current directory.
+
+```bash
+pricectl init
+pricectl init --force   # Overwrite existing files
+```
+
+Creates the following files if they don't already exist:
+
+| File | Description |
+|------|-------------|
+| `pricectl.ts` | Example stack definition |
+| `package.json` | Project manifest with `synth`, `diff`, and `deploy` scripts |
+| `tsconfig.json` | TypeScript compiler configuration |
+| `.env.example` | Template for your Stripe API key |
+| `.gitignore` | Sensible defaults (`.env`, `pricectl.out/`, `node_modules/`) |
+
+**Flags**
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--force` | `-f` | Overwrite existing files |
+
+---
+
+### `pricectl synth`
+
+Synthesize your stack into a JSON manifest (`pricectl.out/manifest.json`).
+
+```bash
+pricectl synth
+pricectl synth --app ./infra/main.ts
+pricectl synth --output ./build
+```
+
+**Flags**
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--app` | `-a` | `./pricectl.ts` | Path to the stack definition file |
+| `--output` | `-o` | `./pricectl.out` | Output directory for the manifest |
+
+---
+
+### `pricectl diff`
+
+Show the difference between your local stack definition and the resources currently deployed in Stripe.
+
+```bash
+pricectl diff
+pricectl diff --app ./infra/main.ts
+```
+
+**Flags**
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--app` | `-a` | `./pricectl.ts` | Path to the stack definition file |
+
+---
+
+### `pricectl deploy`
+
+Deploy your stack to Stripe (creates or updates resources).
+
+```bash
+pricectl deploy
+pricectl deploy --app ./infra/main.ts
+```
+
+**Flags**
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--app` | `-a` | `./pricectl.ts` | Path to the stack definition file |
+
+---
+
+### `pricectl destroy`
+
+Remove all resources defined in your stack from Stripe.
+
+```bash
+pricectl destroy --force
+```
+
+> **Warning:** This action is irreversible. Use `--force` to skip the confirmation prompt.
+
+**Flags**
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--force` | `-f` | Skip confirmation prompt |
+
+---
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `STRIPE_SECRET_KEY` | Your Stripe secret key (`sk_test_...` or `sk_live_...`) |
+
+The key can also be supplied via `Stack` props in your stack definition file.
+
+## Project Structure
+
+After running `pricectl init` your project will look like this:
+
+```
+my-pricing/
+├── pricectl.ts        # Stack definition (edit this)
+├── package.json
+├── tsconfig.json
+├── .env.example
+└── .gitignore
+```
+
+### Example `pricectl.ts`
+
+```typescript
+import { Stack } from '@pricectl/core';
+import { Product, Price, Coupon } from '@pricectl/constructs';
+
+const stack = new Stack(undefined, 'MyStack', {
+  description: 'My Stripe Infrastructure',
+});
+
+const product = new Product(stack, 'PremiumPlan', {
+  name: 'Premium Plan',
+  description: 'Access to all premium features',
+  active: true,
+});
+
+new Price(stack, 'MonthlyPrice', {
+  product,
+  currency: 'usd',
+  unitAmount: 1999, // $19.99/month
+  recurring: { interval: 'month' },
+});
+
+new Coupon(stack, 'WelcomeCoupon', {
+  name: 'Welcome Discount',
+  percentOff: 20,
+  duration: 'once',
+});
+
+export default stack;
+```
+
+## Related Packages
+
+| Package | Description |
+|---------|-------------|
+| [`@pricectl/core`](../core/README.md) | Core IaC framework (Construct, Stack, Resource) |
+| [`@pricectl/constructs`](../constructs/README.md) | Stripe resource constructs (Product, Price, Coupon) |
+
+## License
+
+MIT

--- a/packages/constructs/README.md
+++ b/packages/constructs/README.md
@@ -1,0 +1,210 @@
+# @pricectl/constructs
+
+Stripe pricing resource constructs for [pricectl](https://github.com/hideokamoto/pricectl) — a kubectl-style tool for managing Stripe pricing resources with TypeScript.
+
+## Installation
+
+```bash
+npm install @pricectl/constructs @pricectl/core
+# or
+pnpm add @pricectl/constructs @pricectl/core
+```
+
+## Overview
+
+`@pricectl/constructs` provides ready-to-use TypeScript classes for Stripe pricing resources. Each construct maps directly to a Stripe API object and exposes type-safe props.
+
+| Construct | Stripe Resource |
+|-----------|----------------|
+| `Product` | [Stripe Product](https://stripe.com/docs/api/products) |
+| `Price` | [Stripe Price](https://stripe.com/docs/api/prices) |
+| `Coupon` | [Stripe Coupon](https://stripe.com/docs/api/coupons) |
+
+## Usage
+
+```typescript
+import { Stack } from '@pricectl/core';
+import { Product, Price, Coupon } from '@pricectl/constructs';
+
+const stack = new Stack(undefined, 'MyStack', {
+  description: 'My pricing infrastructure',
+});
+```
+
+---
+
+### Product
+
+Define a Stripe product:
+
+```typescript
+const product = new Product(stack, 'PremiumPlan', {
+  name: 'Premium Plan',
+  description: 'Access to all premium features',
+  active: true,
+});
+```
+
+#### ProductProps
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `name` | `string` | Yes | Product name displayed to customers |
+| `active` | `boolean` | No (default: `true`) | Whether the product is available for purchase |
+| `description` | `string` | No | Product description |
+| `images` | `string[]` | No | Up to 8 image URLs |
+| `metadata` | `Record<string, string>` | No | Arbitrary key-value pairs |
+| `url` | `string` | No | Publicly-accessible webpage URL |
+| `unitLabel` | `string` | No | Label representing units of this product |
+| `statementDescriptor` | `string` | No | Text shown on customer's bank statement |
+| `taxCode` | `string` | No | Stripe tax code ID |
+
+---
+
+### Price
+
+Define pricing for a product (one-time, recurring, tiered, or metered):
+
+```typescript
+// One-time payment
+new Price(stack, 'OneTime', {
+  product,
+  currency: 'usd',
+  unitAmount: 4999, // $49.99
+});
+
+// Monthly subscription
+new Price(stack, 'Monthly', {
+  product,
+  currency: 'usd',
+  unitAmount: 1999, // $19.99
+  recurring: { interval: 'month' },
+});
+
+// Tiered / graduated pricing
+new Price(stack, 'Graduated', {
+  product,
+  currency: 'usd',
+  recurring: { interval: 'month', usageType: 'metered' },
+  tiersMode: 'graduated',
+  tiers: [
+    { upTo: 1000, unitAmount: 10 },
+    { upTo: 10000, unitAmount: 5 },
+    { upTo: 'inf', unitAmount: 2 },
+  ],
+});
+```
+
+#### PriceProps
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `product` | `Product \| string` | Yes | The product this price belongs to |
+| `currency` | `string` | Yes | Three-letter ISO currency code (e.g. `'usd'`) |
+| `unitAmount` | `number` | No | Amount in smallest currency unit (cents for USD) |
+| `unitAmountDecimal` | `string` | No | Decimal amount string (alternative to `unitAmount`) |
+| `active` | `boolean` | No (default: `true`) | Whether the price can be used for new purchases |
+| `nickname` | `string` | No | Brief description of the price |
+| `recurring` | `RecurringProps` | No | Recurring billing configuration |
+| `metadata` | `Record<string, string>` | No | Arbitrary key-value pairs |
+| `lookupKey` | `string` | No | Key to retrieve the price dynamically |
+| `tiersMode` | `'graduated' \| 'volume'` | No | Tiering strategy |
+| `tiers` | `Tier[]` | No | Pricing tiers (requires `tiersMode`) |
+| `transformQuantity` | `{ divideBy: number; round: 'up' \| 'down' }` | No | Quantity transformation before billing |
+
+#### RecurringProps
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `interval` | `'day' \| 'week' \| 'month' \| 'year'` | Yes | Billing frequency |
+| `intervalCount` | `number` | No (default: `1`) | Number of intervals between billings |
+| `usageType` | `'metered' \| 'licensed'` | No | How quantity per period is determined |
+| `trialPeriodDays` | `number` | No | Default trial days when using `trial_from_plan` |
+
+---
+
+### Coupon
+
+Create promotional discounts:
+
+```typescript
+// Percentage discount (one-time)
+new Coupon(stack, 'Launch20', {
+  name: 'Launch Discount',
+  percentOff: 20,
+  duration: 'once',
+});
+
+// Fixed amount discount (repeating for 3 months)
+new Coupon(stack, 'Save10', {
+  name: '$10 Off for 3 Months',
+  amountOff: 1000, // $10.00
+  currency: 'usd',
+  duration: 'repeating',
+  durationInMonths: 3,
+});
+```
+
+> **Note:** Exactly one of `amountOff` or `percentOff` must be specified. When `amountOff` is used, `currency` is required. When `duration` is `'repeating'`, `durationInMonths` is required.
+
+#### CouponProps
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `duration` | `'forever' \| 'once' \| 'repeating'` | Yes | How long the discount applies |
+| `percentOff` | `number` | One of | Percentage discount (0–100) |
+| `amountOff` | `number` | One of | Fixed discount amount in smallest currency unit |
+| `currency` | `string` | Required with `amountOff` | ISO currency code |
+| `durationInMonths` | `number` | Required when `duration='repeating'` | Number of months the coupon applies |
+| `name` | `string` | No | Coupon name displayed to customers |
+| `maxRedemptions` | `number` | No | Maximum total redemptions |
+| `redeemBy` | `number` | No | Unix timestamp for coupon expiry |
+| `metadata` | `Record<string, string>` | No | Arbitrary key-value pairs |
+| `appliesTo` | `{ products?: string[] }` | No | Restrict coupon to specific product IDs |
+
+---
+
+## Complete Example
+
+```typescript
+import { Stack } from '@pricectl/core';
+import { Product, Price, Coupon } from '@pricectl/constructs';
+
+const stack = new Stack(undefined, 'SaaSStack', {
+  description: 'SaaS subscription pricing',
+});
+
+const product = new Product(stack, 'ProPlan', {
+  name: 'Pro Plan',
+  description: 'Full access to all features',
+});
+
+new Price(stack, 'ProMonthly', {
+  product,
+  currency: 'usd',
+  unitAmount: 2900, // $29/month
+  recurring: { interval: 'month' },
+  nickname: 'Pro Monthly',
+});
+
+new Price(stack, 'ProYearly', {
+  product,
+  currency: 'usd',
+  unitAmount: 29000, // $290/year (~17% savings)
+  recurring: { interval: 'year' },
+  nickname: 'Pro Yearly',
+});
+
+new Coupon(stack, 'EarlyBird', {
+  name: 'Early Bird 30% Off',
+  percentOff: 30,
+  duration: 'once',
+  maxRedemptions: 100,
+});
+
+export default stack;
+```
+
+## License
+
+MIT

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,149 @@
+# @pricectl/core
+
+Core IaC framework for [pricectl](https://github.com/hideokamoto/pricectl) — a kubectl-style tool for managing Stripe pricing resources with TypeScript.
+
+## Installation
+
+```bash
+npm install @pricectl/core
+# or
+pnpm add @pricectl/core
+```
+
+## Overview
+
+`@pricectl/core` provides the foundational building blocks for defining Stripe infrastructure as code. Inspired by [AWS CDK](https://aws.amazon.com/cdk/), it exposes three base classes:
+
+| Class | Description |
+|-------|-------------|
+| `Construct` | Base class for all pricectl constructs |
+| `Stack` | Container that groups resources for deployment |
+| `Resource` | Abstract base class for Stripe resource constructs |
+
+## Usage
+
+### Stack
+
+A `Stack` is the root container for your Stripe resources. It holds configuration such as the Stripe API key and tags.
+
+```typescript
+import { Stack } from '@pricectl/core';
+
+const stack = new Stack(undefined, 'MyStack', {
+  description: 'My Stripe pricing infrastructure',
+  // apiKey is read from STRIPE_SECRET_KEY env var by default
+});
+```
+
+#### StackProps
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `apiKey` | `string` | Stripe secret key (falls back to `STRIPE_SECRET_KEY` env var) |
+| `description` | `string` | Human-readable description of the stack |
+| `tags` | `Record<string, string>` | Tags applied to all resources in the stack |
+
+#### `stack.synth()`
+
+Synthesizes the stack into a `StackManifest` — a plain JSON-serialisable object describing all resources and their properties.
+
+```typescript
+const manifest = stack.synth();
+console.log(JSON.stringify(manifest, null, 2));
+```
+
+### Construct
+
+`Construct` is the base class for every node in the construct tree. You rarely instantiate it directly; instead, use higher-level classes from `@pricectl/constructs`.
+
+```typescript
+import { Construct } from '@pricectl/core';
+
+class MyConstruct extends Construct {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+  }
+}
+```
+
+#### ConstructNode
+
+Each `Construct` exposes a `node` property of type `ConstructNode` with these members:
+
+| Member | Type | Description |
+|--------|------|-------------|
+| `id` | `string` | Logical ID within its scope |
+| `path` | `string` | Full path from the root (e.g. `MyStack/MyProduct`) |
+| `scope` | `Construct \| undefined` | Parent construct |
+| `children` | `Construct[]` | Direct child constructs |
+| `findAll()` | `Construct[]` | All descendants including self |
+
+### Resource
+
+`Resource` is the abstract base class for Stripe resources. Extend it when building custom resource constructs.
+
+```typescript
+import { Construct, Resource, ResourceProps } from '@pricectl/core';
+
+interface MyResourceProps extends ResourceProps {
+  readonly name: string;
+}
+
+class MyResource extends Resource {
+  constructor(scope: Construct, id: string, props: MyResourceProps) {
+    super(scope, id, props);
+    // … set properties …
+    this.registerResourceMetadata(); // must be called last
+  }
+
+  protected get resourceType(): string {
+    return 'Stripe::MyResource';
+  }
+
+  protected synthesizeProperties(): object {
+    return { name: '…' };
+  }
+}
+```
+
+> **Important:** Always call `this.registerResourceMetadata()` at the **end** of your constructor, after all properties are initialized.
+
+#### ResourceProps
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `physicalId` | `string` | Existing Stripe resource ID (for importing resources) |
+
+## API Reference
+
+### `Stack`
+
+```typescript
+new Stack(scope: Construct | undefined, id: string, props?: StackProps)
+```
+
+- `synth(): StackManifest` — synthesize the stack into a manifest
+
+### `Construct`
+
+```typescript
+new Construct(scope: Construct | undefined, id: string)
+```
+
+- `node: ConstructNode` — access the construct's node metadata
+
+### `Resource` (abstract)
+
+```typescript
+new Resource(scope: Construct, id: string, props?: ResourceProps)
+```
+
+- `physicalId?: string` — Stripe physical ID
+- `stack: Stack` — the owning Stack
+- `registerResourceMetadata(): void` — register synthesized properties (call at end of constructor)
+- `get resourceType(): string` — abstract, return the Stripe resource type string
+- `synthesizeProperties(): any` — abstract, return Stripe API create params
+
+## License
+
+MIT


### PR DESCRIPTION
## Summary

This PR adds comprehensive README documentation for the three core packages in the pricectl monorepo: `@pricectl/core`, `@pricectl/constructs`, and `@pricectl/cli`.

## Key Changes

- **`@pricectl/core` README**: Documents the foundational IaC framework including `Stack`, `Construct`, and `Resource` base classes with API reference and usage examples
- **`@pricectl/constructs` README**: Provides detailed documentation for the three main Stripe resource constructs (`Product`, `Price`, `Coupon`) with complete property tables, usage examples, and a full end-to-end example
- **`@pricectl/cli` README**: Documents the command-line interface with quick start guide, all available commands (`init`, `synth`, `diff`, `deploy`, `destroy`), environment variables, and project structure guidance

## Notable Details

- Each README includes installation instructions, overview tables, and practical code examples
- Property tables document all available options with types, requirements, and descriptions
- The `@pricectl/constructs` README covers advanced pricing scenarios (tiered, metered, graduated pricing)
- The `@pricectl/cli` README provides a complete quick start workflow and explains the generated project structure
- Cross-references between packages help users understand the relationships and dependencies
- All examples are self-contained and runnable

https://claude.ai/code/session_01FyzrvNoaAonBZAE5La5VKK