### PR TITLE
Remove .eslintrc configuration file

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,0 @@
-{
-  "extends": "oclif",
-  "rules": {
-    "unicorn/no-array-instanceof": 0
-  }
-}


### PR DESCRIPTION
This PR removes the `.eslintrc` configuration file from the repository.

## Summary
The ESLint configuration file has been deleted, which means the project will no longer use this local configuration for linting rules.

## Changes
- Removed `.eslintrc` file that extended the "oclif" configuration and disabled the `unicorn/no-array-instanceof` rule

## Notes
If ESLint configuration is still needed, it may be:
- Defined in `package.json` under the `eslintConfig` field
- Handled by a different configuration file (e.g., `.eslintrc.js`, `.eslintrc.json`, or `eslint.config.js`)
- Inherited from a shared configuration package

https://claude.ai/code/session_012PpcUVMULFLrNrsUKeLJU2