### PR TITLE
Add state management for resource tracking across deployments

### DIFF
--- a/packages/cli/src/__tests__/deployer.test.ts
+++ b/packages/cli/src/__tests__/deployer.test.ts
@@ -167,6 +167,7 @@ describe('StripeDeployer', () => {
       it('変更なしのPriceはunchangedになる', async () => {
         const existingPrice = {
           id: 'price_existing',
+          product: 'prod_123',
           currency: 'usd',
           unit_amount: 999,
           unit_amount_decimal: undefined,
@@ -211,6 +212,7 @@ describe('StripeDeployer', () => {
       it('変更ありのPriceは旧Priceを無効化して新規作成する', async () => {
         const existingPrice = {
           id: 'price_old',
+          product: 'prod_123',
           currency: 'usd',
           unit_amount: 500,
           unit_amount_decimal: undefined,

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -99,9 +99,14 @@ export default class Deploy extends Command {
       this.error(`Deployment failed: ${error.message}`);
     } finally {
       // Always save state, even if there were errors during deployment
-      stateManager.save();
-      this.log('');
-      this.log(chalk.gray(`State saved to ${stateManager.getFilePath()}`));
+      try {
+        stateManager.save();
+        this.log('');
+        this.log(chalk.gray(`State saved to ${stateManager.getFilePath()}`));
+      } catch (saveError: any) {
+        this.log('');
+        this.log(chalk.yellow(`Warning: Failed to save state: ${saveError.message}`));
+      }
     }
   }
 }

--- a/packages/cli/src/commands/diff.ts
+++ b/packages/cli/src/commands/diff.ts
@@ -5,6 +5,7 @@ import chalk from 'chalk';
 import { createTwoFilesPatch } from 'diff';
 import Stripe from 'stripe';
 import { StackManifest } from '@pricectl/core';
+import { fetchCurrentResource, normalizeResource } from '../engine/stripe-utils';
 import { StateManager } from '../engine/state';
 
 export default class Diff extends Command {
@@ -56,7 +57,6 @@ export default class Diff extends Command {
     }
 
     try {
-
       const stripe = new Stripe(apiKey, { apiVersion: '2023-10-16' });
       const stateManager = new StateManager(flags['state-file']);
 
@@ -67,7 +67,7 @@ export default class Diff extends Command {
       let hasChanges = false;
 
       for (const resource of manifest.resources) {
-        const current = await this.fetchCurrentResource(stripe, resource, stateManager, manifest.stackId);
+        const current = await fetchCurrentResource(stripe, resource, stateManager, manifest.stackId);
 
         if (!current) {
           this.log(chalk.green(`[+] ${resource.path} [${resource.type}]`));
@@ -103,181 +103,6 @@ export default class Diff extends Command {
     } catch (error: any) {
       this.error(`Diff failed: ${error.message}`);
     }
-  }
-
-  /**
-   * Fetch the current state of a resource from Stripe.
-   * Uses state file for fast lookup first, then falls back to the Search API.
-   */
-  private async fetchCurrentResource(
-    stripe: Stripe,
-    resource: any,
-    stateManager: StateManager,
-    stackId: string,
-  ): Promise<any> {
-    // Try state-based lookup first for Products and Prices
-    if (resource.type === 'Stripe::Product' || resource.type === 'Stripe::Price') {
-      const stateEntry = stateManager.getResource(stackId, resource.id);
-      if (stateEntry?.physicalId) {
-        try {
-          if (resource.type === 'Stripe::Product') {
-            const product = await stripe.products.retrieve(stateEntry.physicalId);
-            if (product && !product.deleted) {
-              return product;
-            }
-          } else {
-            const price = await stripe.prices.retrieve(stateEntry.physicalId);
-            if (price && price.active) {
-              return price;
-            }
-          }
-        } catch {
-          // State entry is stale — fall through to search
-        }
-      }
-    }
-
-    // Fall back to search/retrieve
-    try {
-      // Escape backslashes first, then escape double quotes in resource.id to prevent search query injection
-      const escapedId = resource.id.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-      switch (resource.type) {
-        case 'Stripe::Product': {
-          const result = await stripe.products.search({
-            query: `metadata["pricectl_id"]:"${escapedId}" OR metadata["fillet_id"]:"${escapedId}"`,
-            limit: 1,
-          });
-          return result.data.length > 0 ? result.data[0] : null;
-        }
-        case 'Stripe::Price': {
-          const result = await stripe.prices.search({
-            query: `metadata["pricectl_id"]:"${escapedId}" OR metadata["fillet_id"]:"${escapedId}"`,
-            limit: 1,
-          });
-          return result.data.length > 0 ? result.data[0] : null;
-        }
-        case 'Stripe::Coupon': {
-          return await stripe.coupons.retrieve(resource.id);
-        }
-        default:
-          return null;
-      }
-    } catch (error: any) {
-      // Only return null for resource_missing errors
-      if (error.code === 'resource_missing') {
-        return null;
-      }
-      // Re-throw other errors (auth, network, etc.) to surface them to the user
-      throw error;
-    }
-  }
-
-  /**
-   * Normalize a Stripe resource to match the format of our construct properties.
-   * This ensures accurate comparison by extracting all user-configurable properties.
-   */
-  private normalizeResource(resource: any, resourceType: string): any {
-    const normalized: any = {};
-
-    switch (resourceType) {
-      case 'Stripe::Product':
-        // Include all Product properties
-        if (resource.name !== undefined) normalized.name = resource.name;
-        if (resource.description !== undefined) normalized.description = resource.description;
-        if (resource.active !== undefined) normalized.active = resource.active;
-        if (resource.images) normalized.images = resource.images;
-        if (resource.url !== undefined) normalized.url = resource.url;
-        if (resource.unit_label !== undefined) normalized.unit_label = resource.unit_label;
-        if (resource.statement_descriptor !== undefined) {
-          normalized.statement_descriptor = resource.statement_descriptor;
-        }
-        if (resource.tax_code !== undefined) normalized.tax_code = resource.tax_code;
-        // Exclude pricectl and legacy fillet metadata from comparison
-        if (resource.metadata) {
-          const { pricectl_id: _pid, pricectl_path: _ppath, fillet_id: _fid, fillet_path: _fpath, ...userMetadata } = resource.metadata;
-          if (Object.keys(userMetadata).length > 0) {
-            normalized.metadata = userMetadata;
-          }
-        }
-        break;
-
-      case 'Stripe::Price':
-        // Include all Price properties
-        // Note: product ID is already resolved, so we include it as-is
-        if (resource.product !== undefined) normalized.product = resource.product;
-        if (resource.currency !== undefined) normalized.currency = resource.currency;
-        if (resource.unit_amount !== undefined) normalized.unit_amount = resource.unit_amount;
-        if (resource.unit_amount_decimal !== undefined) {
-          normalized.unit_amount_decimal = resource.unit_amount_decimal;
-        }
-        if (resource.active !== undefined) normalized.active = resource.active;
-        if (resource.nickname !== undefined) normalized.nickname = resource.nickname;
-        if (resource.lookup_key !== undefined) normalized.lookup_key = resource.lookup_key;
-
-        // Recurring properties
-        if (resource.recurring) {
-          normalized.recurring = {};
-          if (resource.recurring.interval !== undefined) {
-            normalized.recurring.interval = resource.recurring.interval;
-          }
-          if (resource.recurring.interval_count !== undefined) {
-            normalized.recurring.interval_count = resource.recurring.interval_count;
-          }
-          if (resource.recurring.usage_type !== undefined) {
-            normalized.recurring.usage_type = resource.recurring.usage_type;
-          }
-          if (resource.recurring.trial_period_days !== undefined) {
-            normalized.recurring.trial_period_days = resource.recurring.trial_period_days;
-          }
-        }
-
-        // Tiers
-        if (resource.tiers_mode !== undefined) normalized.tiers_mode = resource.tiers_mode;
-        if (resource.tiers) {
-          normalized.tiers = resource.tiers.map((tier: any) => ({
-            up_to: tier.up_to,
-            unit_amount: tier.unit_amount,
-            flat_amount: tier.flat_amount,
-          }));
-        }
-
-        // Transform quantity
-        if (resource.transform_quantity) {
-          normalized.transform_quantity = {
-            divide_by: resource.transform_quantity.divide_by,
-            round: resource.transform_quantity.round,
-          };
-        }
-
-        // Exclude pricectl and legacy fillet metadata from comparison
-        if (resource.metadata) {
-          const { pricectl_id: _pid, pricectl_path: _ppath, fillet_id: _fid, fillet_path: _fpath, ...userMetadata } = resource.metadata;
-          if (Object.keys(userMetadata).length > 0) {
-            normalized.metadata = userMetadata;
-          }
-        }
-        break;
-
-      case 'Stripe::Coupon':
-        // Include all Coupon properties
-        if (resource.duration !== undefined) normalized.duration = resource.duration;
-        if (resource.amount_off !== undefined) normalized.amount_off = resource.amount_off;
-        if (resource.currency !== undefined) normalized.currency = resource.currency;
-        if (resource.percent_off !== undefined) normalized.percent_off = resource.percent_off;
-        if (resource.duration_in_months !== undefined) {
-          normalized.duration_in_months = resource.duration_in_months;
-        }
-        if (resource.max_redemptions !== undefined) {
-          normalized.max_redemptions = resource.max_redemptions;
-        }
-        if (resource.name !== undefined) normalized.name = resource.name;
-        if (resource.redeem_by !== undefined) normalized.redeem_by = resource.redeem_by;
-        if (resource.applies_to !== undefined) normalized.applies_to = resource.applies_to;
-        if (resource.metadata) normalized.metadata = resource.metadata;
-        break;
-    }
-
-    return normalized;
   }
 
   private colorDiff(patch: string): string {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -166,8 +166,17 @@ dist/
       this.log(chalk.green('✓ Created .gitignore'));
     } else if (flags.force) {
       const existing = fs.readFileSync(gitignorePath, 'utf-8');
-      if (!existing.includes('pricectl.out/')) {
-        fs.appendFileSync(gitignorePath, '\n' + gitignoreContent + '\n');
+      const linesToAdd: string[] = [];
+      if (!existing.includes('.env')) linesToAdd.push('.env');
+      if (!existing.includes('pricectl.out/')) linesToAdd.push('pricectl.out/');
+      if (!existing.includes('pricectl.state.json')) linesToAdd.push('pricectl.state.json');
+      if (!existing.includes('node_modules/')) linesToAdd.push('node_modules/');
+      if (!existing.includes('dist/')) linesToAdd.push('dist/');
+      if (!existing.includes('*.js')) linesToAdd.push('*.js');
+      if (!existing.includes('*.d.ts')) linesToAdd.push('*.d.ts');
+
+      if (linesToAdd.length > 0) {
+        fs.appendFileSync(gitignorePath, '\n' + linesToAdd.join('\n') + '\n');
         this.log(chalk.green('✓ Updated .gitignore'));
       }
     }

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -154,6 +154,7 @@ export default stack;
     const gitignoreContent = `
 .env
 pricectl.out/
+pricectl.state.json
 node_modules/
 dist/
 *.js

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -166,14 +166,12 @@ dist/
       this.log(chalk.green('✓ Created .gitignore'));
     } else if (flags.force) {
       const existing = fs.readFileSync(gitignorePath, 'utf-8');
+      const existingLines = new Set(existing.split('\n').map(l => l.trim()));
       const linesToAdd: string[] = [];
-      if (!existing.includes('.env')) linesToAdd.push('.env');
-      if (!existing.includes('pricectl.out/')) linesToAdd.push('pricectl.out/');
-      if (!existing.includes('pricectl.state.json')) linesToAdd.push('pricectl.state.json');
-      if (!existing.includes('node_modules/')) linesToAdd.push('node_modules/');
-      if (!existing.includes('dist/')) linesToAdd.push('dist/');
-      if (!existing.includes('*.js')) linesToAdd.push('*.js');
-      if (!existing.includes('*.d.ts')) linesToAdd.push('*.d.ts');
+      const requiredEntries = ['.env', 'pricectl.out/', 'pricectl.state.json', 'node_modules/', 'dist/', '*.js', '*.d.ts'];
+      for (const entry of requiredEntries) {
+        if (!existingLines.has(entry)) linesToAdd.push(entry);
+      }
 
       if (linesToAdd.length > 0) {
         fs.appendFileSync(gitignorePath, '\n' + linesToAdd.join('\n') + '\n');

--- a/packages/cli/src/engine/__tests__/state.test.ts
+++ b/packages/cli/src/engine/__tests__/state.test.ts
@@ -1,0 +1,246 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { StateManager, StateFile, ResourceState } from '../state';
+
+describe('StateManager', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pricectl-state-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('constructor', () => {
+    it('creates empty state when no file exists', () => {
+      const manager = new StateManager(tmpDir);
+      expect(manager.getStack('MyStack')).toBeUndefined();
+    });
+
+    it('loads existing state file', () => {
+      const state: StateFile = {
+        version: 1,
+        stacks: {
+          MyStack: {
+            resources: {
+              BasicProduct: {
+                logicalId: 'BasicProduct',
+                physicalId: 'prod_123',
+                type: 'Stripe::Product',
+                path: 'MyStack/BasicProduct',
+                lastDeployedAt: '2024-01-01T00:00:00.000Z',
+                propertiesHash: 'abc123',
+              },
+            },
+          },
+        },
+      };
+      fs.writeFileSync(
+        path.join(tmpDir, 'pricectl.state.json'),
+        JSON.stringify(state),
+      );
+
+      const manager = new StateManager(tmpDir);
+      const resource = manager.getResource('MyStack', 'BasicProduct');
+      expect(resource).toBeDefined();
+      expect(resource!.physicalId).toBe('prod_123');
+    });
+
+    it('starts fresh when state file has wrong version', () => {
+      const state = { version: 999, stacks: {} };
+      fs.writeFileSync(
+        path.join(tmpDir, 'pricectl.state.json'),
+        JSON.stringify(state),
+      );
+
+      const manager = new StateManager(tmpDir);
+      expect(manager.getStack('MyStack')).toBeUndefined();
+    });
+
+    it('starts fresh when state file is corrupted', () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'pricectl.state.json'),
+        'not valid json!!!',
+      );
+
+      const manager = new StateManager(tmpDir);
+      expect(manager.getStack('MyStack')).toBeUndefined();
+    });
+  });
+
+  describe('getResource / setResource', () => {
+    it('returns undefined for non-existent resource', () => {
+      const manager = new StateManager(tmpDir);
+      expect(manager.getResource('MyStack', 'NonExistent')).toBeUndefined();
+    });
+
+    it('sets and retrieves a resource', () => {
+      const manager = new StateManager(tmpDir);
+      const resource: ResourceState = {
+        logicalId: 'BasicProduct',
+        physicalId: 'prod_abc',
+        type: 'Stripe::Product',
+        path: 'MyStack/BasicProduct',
+        lastDeployedAt: '2024-01-01T00:00:00.000Z',
+        propertiesHash: 'hash123',
+      };
+
+      manager.setResource('MyStack', resource);
+      const retrieved = manager.getResource('MyStack', 'BasicProduct');
+      expect(retrieved).toEqual(resource);
+    });
+
+    it('creates stack entry if not present', () => {
+      const manager = new StateManager(tmpDir);
+      expect(manager.getStack('NewStack')).toBeUndefined();
+
+      manager.setResource('NewStack', {
+        logicalId: 'Res',
+        physicalId: 'prod_x',
+        type: 'Stripe::Product',
+        path: 'NewStack/Res',
+        lastDeployedAt: '2024-01-01T00:00:00.000Z',
+        propertiesHash: 'h',
+      });
+
+      expect(manager.getStack('NewStack')).toBeDefined();
+    });
+  });
+
+  describe('removeResource', () => {
+    it('removes a resource from state', () => {
+      const manager = new StateManager(tmpDir);
+      manager.setResource('MyStack', {
+        logicalId: 'Prod',
+        physicalId: 'prod_1',
+        type: 'Stripe::Product',
+        path: 'MyStack/Prod',
+        lastDeployedAt: '2024-01-01T00:00:00.000Z',
+        propertiesHash: 'h',
+      });
+
+      manager.removeResource('MyStack', 'Prod');
+      expect(manager.getResource('MyStack', 'Prod')).toBeUndefined();
+    });
+
+    it('cleans up empty stack entry', () => {
+      const manager = new StateManager(tmpDir);
+      manager.setResource('MyStack', {
+        logicalId: 'Prod',
+        physicalId: 'prod_1',
+        type: 'Stripe::Product',
+        path: 'MyStack/Prod',
+        lastDeployedAt: '2024-01-01T00:00:00.000Z',
+        propertiesHash: 'h',
+      });
+
+      manager.removeResource('MyStack', 'Prod');
+      expect(manager.getStack('MyStack')).toBeUndefined();
+    });
+
+    it('does not error when removing from non-existent stack', () => {
+      const manager = new StateManager(tmpDir);
+      expect(() => manager.removeResource('NoStack', 'NoRes')).not.toThrow();
+    });
+  });
+
+  describe('removeStack', () => {
+    it('removes an entire stack', () => {
+      const manager = new StateManager(tmpDir);
+      manager.setResource('MyStack', {
+        logicalId: 'Prod',
+        physicalId: 'prod_1',
+        type: 'Stripe::Product',
+        path: 'MyStack/Prod',
+        lastDeployedAt: '2024-01-01T00:00:00.000Z',
+        propertiesHash: 'h',
+      });
+
+      manager.removeStack('MyStack');
+      expect(manager.getStack('MyStack')).toBeUndefined();
+      expect(manager.getResource('MyStack', 'Prod')).toBeUndefined();
+    });
+  });
+
+  describe('save', () => {
+    it('persists state to disk', () => {
+      const manager = new StateManager(tmpDir);
+      manager.setResource('MyStack', {
+        logicalId: 'Prod',
+        physicalId: 'prod_1',
+        type: 'Stripe::Product',
+        path: 'MyStack/Prod',
+        lastDeployedAt: '2024-01-01T00:00:00.000Z',
+        propertiesHash: 'h',
+      });
+      manager.save();
+
+      const filePath = path.join(tmpDir, 'pricectl.state.json');
+      expect(fs.existsSync(filePath)).toBe(true);
+
+      const content = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+      expect(content.version).toBe(1);
+      expect(content.stacks.MyStack.resources.Prod.physicalId).toBe('prod_1');
+    });
+
+    it('can be loaded by a new StateManager instance', () => {
+      const manager1 = new StateManager(tmpDir);
+      manager1.setResource('MyStack', {
+        logicalId: 'Prod',
+        physicalId: 'prod_1',
+        type: 'Stripe::Product',
+        path: 'MyStack/Prod',
+        lastDeployedAt: '2024-01-01T00:00:00.000Z',
+        propertiesHash: 'h',
+      });
+      manager1.save();
+
+      const manager2 = new StateManager(tmpDir);
+      const resource = manager2.getResource('MyStack', 'Prod');
+      expect(resource).toBeDefined();
+      expect(resource!.physicalId).toBe('prod_1');
+    });
+  });
+
+  describe('computePropertiesHash', () => {
+    it('returns consistent hash for same properties', () => {
+      const props = { name: 'Test Product', active: true };
+      const hash1 = StateManager.computePropertiesHash(props);
+      const hash2 = StateManager.computePropertiesHash(props);
+      expect(hash1).toBe(hash2);
+    });
+
+    it('returns same hash regardless of key order', () => {
+      const props1 = { name: 'Test', active: true };
+      const props2 = { active: true, name: 'Test' };
+      expect(StateManager.computePropertiesHash(props1)).toBe(
+        StateManager.computePropertiesHash(props2),
+      );
+    });
+
+    it('returns different hash for different properties', () => {
+      const props1 = { name: 'Product A' };
+      const props2 = { name: 'Product B' };
+      expect(StateManager.computePropertiesHash(props1)).not.toBe(
+        StateManager.computePropertiesHash(props2),
+      );
+    });
+
+    it('returns a 16-char hex string', () => {
+      const hash = StateManager.computePropertiesHash({ foo: 'bar' });
+      expect(hash).toMatch(/^[0-9a-f]{16}$/);
+    });
+  });
+
+  describe('getFilePath', () => {
+    it('returns the resolved state file path', () => {
+      const manager = new StateManager(tmpDir);
+      expect(manager.getFilePath()).toBe(
+        path.join(tmpDir, 'pricectl.state.json'),
+      );
+    });
+  });
+});

--- a/packages/cli/src/engine/__tests__/state.test.ts
+++ b/packages/cli/src/engine/__tests__/state.test.ts
@@ -233,6 +233,58 @@ describe('StateManager', () => {
       const hash = StateManager.computePropertiesHash({ foo: 'bar' });
       expect(hash).toMatch(/^[0-9a-f]{16}$/);
     });
+
+    it('handles nested objects regardless of key order', () => {
+      const props1 = {
+        name: 'Product',
+        recurring: { interval: 'month', intervalCount: 1 },
+        active: true,
+      };
+      const props2 = {
+        active: true,
+        recurring: { intervalCount: 1, interval: 'month' },
+        name: 'Product',
+      };
+      expect(StateManager.computePropertiesHash(props1)).toBe(
+        StateManager.computePropertiesHash(props2),
+      );
+    });
+
+    it('handles deeply nested objects', () => {
+      const props1 = {
+        level1: {
+          level2: { z: 3, a: 1, b: 2 },
+          x: 'test',
+        },
+      };
+      const props2 = {
+        level1: {
+          x: 'test',
+          level2: { a: 1, b: 2, z: 3 },
+        },
+      };
+      expect(StateManager.computePropertiesHash(props1)).toBe(
+        StateManager.computePropertiesHash(props2),
+      );
+    });
+
+    it('handles arrays within objects', () => {
+      const props1 = {
+        tiers: [
+          { upTo: 100, unitAmount: 10 },
+          { upTo: 200, unitAmount: 20 },
+        ],
+      };
+      const props2 = {
+        tiers: [
+          { upTo: 100, unitAmount: 10 },
+          { upTo: 200, unitAmount: 20 },
+        ],
+      };
+      expect(StateManager.computePropertiesHash(props1)).toBe(
+        StateManager.computePropertiesHash(props2),
+      );
+    });
   });
 
   describe('getFilePath', () => {

--- a/packages/cli/src/engine/deployer.ts
+++ b/packages/cli/src/engine/deployer.ts
@@ -332,11 +332,11 @@ export class StripeDeployer {
         const destroyed = await this.destroyResource(resource, manifest.stackId);
         if (destroyed) {
           result.destroyed.push(destroyed);
+        }
 
-          // Remove from state
-          if (this.stateManager) {
-            this.stateManager.removeResource(manifest.stackId, resource.id);
-          }
+        // Always clean state when destroyResource succeeds (even if resource was already gone)
+        if (this.stateManager) {
+          this.stateManager.removeResource(manifest.stackId, resource.id);
         }
       } catch (error: any) {
         result.errors.push({

--- a/packages/cli/src/engine/deployer.ts
+++ b/packages/cli/src/engine/deployer.ts
@@ -305,6 +305,11 @@ export class StripeDeployer {
    * the old price and creating a new one.
    */
   private comparePriceProperties(existing: Stripe.Price, desired: Stripe.PriceCreateParams): boolean {
+    // Compare product linkage (critical for Prices since they're immutable)
+    const existingProduct = typeof existing.product === 'string' ? existing.product : existing.product?.id;
+    const desiredProduct = typeof desired.product === 'string' ? desired.product : (desired.product as unknown as Stripe.Product)?.id;
+    if (existingProduct !== desiredProduct) return false;
+
     // Compare basic properties
     if (existing.currency !== desired.currency) return false;
     if (existing.unit_amount !== desired.unit_amount) return false;

--- a/packages/cli/src/engine/state.ts
+++ b/packages/cli/src/engine/state.ts
@@ -1,0 +1,104 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as crypto from 'crypto';
+
+export interface ResourceState {
+  logicalId: string;
+  physicalId: string;
+  type: string;
+  path: string;
+  lastDeployedAt: string;
+  propertiesHash: string;
+}
+
+export interface StackState {
+  resources: Record<string, ResourceState>;
+}
+
+export interface StateFile {
+  version: number;
+  stacks: Record<string, StackState>;
+}
+
+const STATE_VERSION = 1;
+const DEFAULT_STATE_FILE = 'pricectl.state.json';
+
+export class StateManager {
+  private state: StateFile;
+  private filePath: string;
+
+  constructor(stateDir?: string) {
+    this.filePath = path.resolve(stateDir || process.cwd(), DEFAULT_STATE_FILE);
+    this.state = this.load();
+  }
+
+  private load(): StateFile {
+    try {
+      if (fs.existsSync(this.filePath)) {
+        const raw = fs.readFileSync(this.filePath, 'utf-8');
+        const parsed = JSON.parse(raw);
+        if (parsed.version === STATE_VERSION) {
+          return parsed;
+        }
+        // Unsupported version — start fresh
+        return this.createEmpty();
+      }
+    } catch {
+      // Corrupted or unreadable — start fresh
+    }
+    return this.createEmpty();
+  }
+
+  private createEmpty(): StateFile {
+    return { version: STATE_VERSION, stacks: {} };
+  }
+
+  save(): void {
+    const dir = path.dirname(this.filePath);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+    // Atomic write via temp file
+    const tmpPath = this.filePath + '.tmp';
+    fs.writeFileSync(tmpPath, JSON.stringify(this.state, null, 2) + '\n', 'utf-8');
+    fs.renameSync(tmpPath, this.filePath);
+  }
+
+  getFilePath(): string {
+    return this.filePath;
+  }
+
+  getResource(stackId: string, logicalId: string): ResourceState | undefined {
+    return this.state.stacks[stackId]?.resources[logicalId];
+  }
+
+  setResource(stackId: string, resource: ResourceState): void {
+    if (!this.state.stacks[stackId]) {
+      this.state.stacks[stackId] = { resources: {} };
+    }
+    this.state.stacks[stackId].resources[resource.logicalId] = resource;
+  }
+
+  removeResource(stackId: string, logicalId: string): void {
+    if (this.state.stacks[stackId]) {
+      delete this.state.stacks[stackId].resources[logicalId];
+      // Clean up empty stack entries
+      if (Object.keys(this.state.stacks[stackId].resources).length === 0) {
+        delete this.state.stacks[stackId];
+      }
+    }
+  }
+
+  removeStack(stackId: string): void {
+    delete this.state.stacks[stackId];
+  }
+
+  getStack(stackId: string): StackState | undefined {
+    return this.state.stacks[stackId];
+  }
+
+  static computePropertiesHash(properties: any): string {
+    const json = JSON.stringify(properties, Object.keys(properties).sort());
+    return crypto.createHash('sha256').update(json).digest('hex').slice(0, 16);
+  }
+}

--- a/packages/cli/src/engine/state.ts
+++ b/packages/cli/src/engine/state.ts
@@ -37,7 +37,12 @@ export class StateManager {
       if (fs.existsSync(this.filePath)) {
         const raw = fs.readFileSync(this.filePath, 'utf-8');
         const parsed = JSON.parse(raw);
-        if (parsed.version === STATE_VERSION) {
+        if (
+          parsed.version === STATE_VERSION &&
+          parsed.stacks !== null &&
+          typeof parsed.stacks === 'object' &&
+          !Array.isArray(parsed.stacks)
+        ) {
           return parsed;
         }
         // Unsupported version — start fresh

--- a/packages/cli/src/engine/stripe-utils.ts
+++ b/packages/cli/src/engine/stripe-utils.ts
@@ -39,7 +39,10 @@ export async function findExistingProduct(
         if (product && !product.deleted) {
           return product;
         }
-      } catch {
+      } catch (error: any) {
+        if (error?.code !== 'resource_missing') {
+          throw error;
+        }
         // Physical ID from state is stale — fall through to search
       }
     }
@@ -78,10 +81,13 @@ export async function findExistingPrice(
     if (stateEntry?.physicalId) {
       try {
         const price = await stripe.prices.retrieve(stateEntry.physicalId);
-        if (price && price.active) {
+        if (price) {
           return price;
         }
-      } catch {
+      } catch (error: any) {
+        if (error?.code !== 'resource_missing') {
+          throw error;
+        }
         // Physical ID from state is stale — fall through to search
       }
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,13 +44,13 @@ importers:
 
   examples/advanced-pricing:
     dependencies:
-      '@fillet/cli':
+      '@pricectl/cli':
         specifier: workspace:*
         version: link:../../packages/cli
-      '@fillet/constructs':
+      '@pricectl/constructs':
         specifier: workspace:*
         version: link:../../packages/constructs
-      '@fillet/core':
+      '@pricectl/core':
         specifier: workspace:*
         version: link:../../packages/core
     devDependencies:
@@ -63,13 +63,13 @@ importers:
 
   examples/basic-subscription:
     dependencies:
-      '@fillet/cli':
+      '@pricectl/cli':
         specifier: workspace:*
         version: link:../../packages/cli
-      '@fillet/constructs':
+      '@pricectl/constructs':
         specifier: workspace:*
         version: link:../../packages/constructs
-      '@fillet/core':
+      '@pricectl/core':
         specifier: workspace:*
         version: link:../../packages/core
     devDependencies:
@@ -82,18 +82,18 @@ importers:
 
   packages/cli:
     dependencies:
-      '@fillet/constructs':
-        specifier: workspace:*
-        version: link:../constructs
-      '@fillet/core':
-        specifier: workspace:*
-        version: link:../core
       '@oclif/core':
         specifier: ^3.15.0
         version: 3.27.0
       '@oclif/plugin-help':
         specifier: ^6.0.9
         version: 6.2.36
+      '@pricectl/constructs':
+        specifier: workspace:*
+        version: link:../constructs
+      '@pricectl/core':
+        specifier: workspace:*
+        version: link:../core
       chalk:
         specifier: ^4.1.2
         version: 4.1.2
@@ -116,7 +116,7 @@ importers:
 
   packages/constructs:
     dependencies:
-      '@fillet/core':
+      '@pricectl/core':
         specifier: workspace:*
         version: link:../core
       stripe:


### PR DESCRIPTION
## Summary
Introduces a `StateManager` class to track deployed Stripe resources and their mappings, enabling faster resource lookups and better deployment idempotency. The state is persisted to disk and used by the deployer and diff commands to avoid repeated Search API calls.

## Key Changes

- **New `StateManager` class** (`packages/cli/src/engine/state.ts`):
  - Manages in-memory state of deployed resources with stack and resource-level organization
  - Persists state to `pricectl.state.json` with atomic writes via temporary files
  - Provides resource CRUD operations (`getResource`, `setResource`, `removeResource`, `removeStack`)
  - Includes `computePropertiesHash()` static method for detecting property changes (16-char SHA256 hex)
  - Handles corrupted/versioned state files gracefully by starting fresh

- **Comprehensive test suite** (`packages/cli/src/engine/__tests__/state.test.ts`):
  - 246 lines of tests covering constructor, resource operations, stack cleanup, persistence, and hashing
  - Tests for error handling (corrupted files, version mismatches)
  - Validates state round-trip persistence

- **Updated `StripeDeployer`**:
  - Accepts optional `StateManager` in constructor
  - Records deployed resources in state with metadata (logicalId, physicalId, type, path, timestamp, propertiesHash)
  - Implements state-based lookup in `findExistingProduct()` and `findExistingPrice()` before falling back to Search API
  - Removes resources from state during destroy operations

- **Updated CLI commands**:
  - `deploy`: Initializes `StateManager`, passes to deployer, and saves state after successful deployment
  - `destroy`: Loads state, passes to deployer, and saves state after destruction
  - `diff`: Uses state for fast resource lookup before falling back to Search API
  - All commands accept new `--state-file` flag to specify state directory

- **Updated `.gitignore`**: Added `pricectl.state.json` to prevent state file commits

## Implementation Details

- State lookup is attempted first for Products and Prices, with graceful fallback to Search API if state entries are stale
- Empty stack entries are automatically cleaned up when their last resource is removed
- Properties hash enables future change detection without comparing full objects
- Atomic file writes prevent corruption on interrupted saves

https://claude.ai/code/session_01DtXAES4UqoWKCzrKXW7xax