### PR TITLE
Refactor metadata stripping and improve error handling in Stripe utils

### DIFF
--- a/packages/cli/src/engine/deployer.ts
+++ b/packages/cli/src/engine/deployer.ts
@@ -1,6 +1,6 @@
 import Stripe from 'stripe';
 import { StackManifest, ResourceManifest } from '@pricectl/core';
-import { findExistingProduct, findExistingPrice } from './stripe-utils';
+import { findExistingProduct as stripeFindExistingProduct, findExistingPrice as stripeFindExistingPrice } from './stripe-utils';
 
 export interface DeployResult {
   stackId: string;
@@ -212,11 +212,11 @@ export class StripeDeployer {
   }
 
   private findExistingProduct(logicalId: string): Promise<Stripe.Product | null> {
-    return findExistingProduct(this.stripe, logicalId);
+    return stripeFindExistingProduct(this.stripe, logicalId);
   }
 
   private findExistingPrice(logicalId: string): Promise<Stripe.Price | null> {
-    return findExistingPrice(this.stripe, logicalId);
+    return stripeFindExistingPrice(this.stripe, logicalId);
   }
 
   /**


### PR DESCRIPTION
## Summary
This PR refactors the Stripe utilities to reduce code duplication and improve error handling. The main changes include extracting repeated metadata filtering logic into a reusable function and making error handling more explicit for unsupported resource types.

## Key Changes
- **Extract `stripInternalMetadata()` function**: Created a new utility function to centralize the logic for removing internal metadata keys (`pricectl_id`, `pricectl_path`, `fillet_id`, `fillet_path`) from Stripe resources. This function is now used consistently across Product, Price, and Coupon normalization.
- **Improve error handling**: Changed `fetchCurrentResource()` to throw an explicit error for unsupported resource types instead of silently returning `null`, making debugging easier.
- **Rename imports in deployer**: Added namespace prefixes (`stripeFindExistingProduct`, `stripeFindExistingPrice`) to imported functions to avoid potential naming conflicts and improve code clarity.

## Implementation Details
- The `stripInternalMetadata()` function returns `undefined` if no user-defined metadata remains after stripping internal keys, simplifying null checks in calling code.
- All three resource type handlers (Product, Price, Coupon) now use the same metadata filtering approach, reducing maintenance burden and ensuring consistent behavior.

https://claude.ai/code/session_01VEk9AsymtVLF5wscCpowYF