### PR TITLE
Remove stripe dependency from core package

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,9 +15,7 @@
   },
   "keywords": ["stripe", "iac", "infrastructure", "cdk"],
   "license": "MIT",
-  "dependencies": {
-    "stripe": "^14.9.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@types/node": "^20.10.0",
     "typescript": "^5.3.3"


### PR DESCRIPTION
## Summary
Removed the `stripe` npm package from the core package's dependencies.

## Changes
- Removed `stripe` (^14.9.0) from the dependencies object in `packages/core/package.json`
- The dependencies object is now empty

## Notes
This change indicates that the core package no longer directly depends on the Stripe library. This could be part of a refactoring effort to decouple dependencies, move Stripe integration to a separate package, or reduce the core package's footprint.

https://claude.ai/code/session_01QEvKA5Ng9pCjzgrfwSMZkK