### PR TITLE
Add configurable Stripe API version support

### DIFF
--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -52,7 +52,7 @@ export default class Deploy extends Command {
 
     try {
       // Deploy using the deployer
-      const deployer = new StripeDeployer(apiKey);
+      const deployer = new StripeDeployer(apiKey, manifest.apiVersion);
       const result = await deployer.deploy(manifest);
 
       // Display results

--- a/packages/cli/src/commands/destroy.ts
+++ b/packages/cli/src/commands/destroy.ts
@@ -72,7 +72,7 @@ export default class Destroy extends Command {
       this.log('Destroying resources...');
       this.log('');
 
-      const deployer = new StripeDeployer(apiKey);
+      const deployer = new StripeDeployer(apiKey, manifest.apiVersion);
       const result = await deployer.destroy(manifest);
 
       // Display results

--- a/packages/cli/src/commands/diff.ts
+++ b/packages/cli/src/commands/diff.ts
@@ -53,8 +53,8 @@ export default class Diff extends Command {
     }
 
     try {
-
-      const stripe = new Stripe(apiKey, { apiVersion: '2023-10-16' });
+      const apiVersion = stack.apiVersion || manifest.apiVersion || '2024-12-18.acacia';
+      const stripe = new Stripe(apiKey, { apiVersion: apiVersion as any });
 
       // Fetch current state from Stripe
       this.log(chalk.bold(`Stack: ${manifest.stackId}`));

--- a/packages/cli/src/engine/deployer.ts
+++ b/packages/cli/src/engine/deployer.ts
@@ -35,9 +35,9 @@ export class StripeDeployer {
   private stripe: Stripe;
   private logicalToPhysicalId: Map<string, string> = new Map();
 
-  constructor(apiKey: string) {
+  constructor(apiKey: string, apiVersion: string = '2024-12-18.acacia') {
     this.stripe = new Stripe(apiKey, {
-      apiVersion: '2023-10-16',
+      apiVersion: apiVersion as any,
     });
   }
 

--- a/packages/core/src/stack.ts
+++ b/packages/core/src/stack.ts
@@ -7,6 +7,12 @@ export interface StackProps {
   readonly apiKey?: string;
 
   /**
+   * Stripe API version (e.g., '2024-12-18.acacia')
+   * Defaults to the latest stable version if not specified
+   */
+  readonly apiVersion?: string;
+
+  /**
    * Stack description
    */
   readonly description?: string;
@@ -23,6 +29,7 @@ export interface StackProps {
  */
 export class Stack extends Construct {
   public readonly apiKey?: string;
+  public readonly apiVersion?: string;
   public readonly description?: string;
   public readonly tags: Record<string, string>;
 
@@ -30,6 +37,7 @@ export class Stack extends Construct {
     super(scope, id);
 
     this.apiKey = props.apiKey || process.env.STRIPE_SECRET_KEY;
+    this.apiVersion = props.apiVersion || '2024-12-18.acacia';
     this.description = props.description;
     this.tags = props.tags || {};
 
@@ -63,6 +71,7 @@ export class Stack extends Construct {
 
     return {
       stackId: this.node.id,
+      apiVersion: this.apiVersion,
       description: this.description,
       tags: this.tags,
       resources,
@@ -79,6 +88,7 @@ export interface ResourceManifest {
 
 export interface StackManifest {
   stackId: string;
+  apiVersion?: string;
   description?: string;
   tags: Record<string, string>;
   resources: ResourceManifest[];


### PR DESCRIPTION
## Summary
This PR adds support for configurable Stripe API versions across the Stack and deployment infrastructure, allowing users to specify which API version to use instead of being locked to a hardcoded version.

## Key Changes
- **Stack Configuration**: Added `apiVersion` property to `StackProps` interface with a default value of `'2024-12-18.acacia'`
- **Stack Class**: Updated to store and expose the `apiVersion` property, defaulting to the latest stable version if not specified
- **Stack Manifest**: Added `apiVersion` field to `StackManifest` interface for persistence and retrieval
- **StripeDeployer**: Modified constructor to accept `apiVersion` parameter (defaults to `'2024-12-18.acacia'`) and pass it to Stripe client initialization
- **CLI Commands**: Updated `deploy`, `destroy`, and `diff` commands to use the configured API version from the manifest/stack instead of hardcoded `'2023-10-16'`

## Implementation Details
- The API version defaults to `'2024-12-18.acacia'` at multiple levels (Stack, StripeDeployer) to ensure consistency
- The `diff` command prioritizes the stack's API version, falling back to the manifest's version, then to the default
- All Stripe client instantiations now use the configurable version instead of the previously hardcoded `'2023-10-16'`
- The change is backward compatible as the manifest's `apiVersion` field is optional

https://claude.ai/code/session_01LvQtEV3cL5g79nny8UG6xy