### PR TITLE
Add dry-run flag and improve error messages for CLI commands

### DIFF
--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import chalk from 'chalk';
 import { StripeDeployer } from '../engine/deployer';
-import { StackManifest } from '@pricectl/core';
+import { StackManifest, STRIPE_API_KEY_MISSING_ERROR } from '@pricectl/core';
 
 export default class Deploy extends Command {
   static description = 'Deploy the stack to Stripe';
@@ -58,7 +58,10 @@ export default class Deploy extends Command {
       this.log(chalk.bold(`Resources to deploy (${manifest.resources.length}):`));
       for (const resource of manifest.resources) {
         this.log(chalk.green(`  + ${resource.path} [${resource.type}]`));
-        this.log(`    Properties: ${JSON.stringify(resource.properties, null, 2).replace(/\n/g, '\n    ')}`);
+        this.log('    Properties:');
+        for (const line of JSON.stringify(resource.properties, null, 2).split('\n')) {
+          this.log(`    ${line}`);
+        }
       }
       this.log('');
       this.log(chalk.bold('Summary:'));
@@ -69,14 +72,7 @@ export default class Deploy extends Command {
     // Get Stripe API key
     const apiKey = stack.apiKey || process.env.STRIPE_SECRET_KEY;
     if (!apiKey) {
-      this.error(
-        'Stripe API key not found.\n\n' +
-        'To fix this, choose one of:\n' +
-        '  1. Set the environment variable:  export STRIPE_SECRET_KEY=sk_...\n' +
-        '  2. Pass it in the Stack constructor: new Stack(scope, "id", { apiKey: "sk_..." })\n' +
-        '  3. Add STRIPE_SECRET_KEY=sk_... to your .env file',
-        { exit: 1 }
-      );
+      this.error(STRIPE_API_KEY_MISSING_ERROR, { exit: 1 });
     }
 
     try {

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -1,0 +1,6 @@
+export const STRIPE_API_KEY_MISSING_ERROR =
+  'Stripe API key not found.\n\n' +
+  'To fix this, choose one of:\n' +
+  '  1. Set the environment variable:  export STRIPE_SECRET_KEY=sk_...\n' +
+  '  2. Pass it in the Stack constructor: new Stack(scope, "id", { apiKey: "sk_..." })\n' +
+  '  3. Add STRIPE_SECRET_KEY=sk_... to your .env file';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,4 @@
 export * from './construct';
+export * from './errors';
 export * from './stack';
 export * from './resource';

--- a/packages/core/src/stack.ts
+++ b/packages/core/src/stack.ts
@@ -1,4 +1,5 @@
 import { Construct } from './construct';
+import { STRIPE_API_KEY_MISSING_ERROR } from './errors';
 
 export interface StackProps {
   /**
@@ -34,13 +35,7 @@ export class Stack extends Construct {
     this.tags = props.tags || {};
 
     if (!this.apiKey) {
-      throw new Error(
-        'Stripe API key not found.\n\n' +
-        'To fix this, choose one of:\n' +
-        '  1. Set the environment variable:  export STRIPE_SECRET_KEY=sk_...\n' +
-        '  2. Pass it in the Stack constructor: new Stack(scope, "id", { apiKey: "sk_..." })\n' +
-        '  3. Add STRIPE_SECRET_KEY=sk_... to your .env file'
-      );
+      throw new Error(STRIPE_API_KEY_MISSING_ERROR);
     }
   }
 

--- a/packages/core/src/stack.ts
+++ b/packages/core/src/stack.ts
@@ -35,7 +35,11 @@ export class Stack extends Construct {
 
     if (!this.apiKey) {
       throw new Error(
-        'Stripe API key is required. Set it via props.apiKey or STRIPE_SECRET_KEY environment variable.'
+        'Stripe API key not found.\n\n' +
+        'To fix this, choose one of:\n' +
+        '  1. Set the environment variable:  export STRIPE_SECRET_KEY=sk_...\n' +
+        '  2. Pass it in the Stack constructor: new Stack(scope, "id", { apiKey: "sk_..." })\n' +
+        '  3. Add STRIPE_SECRET_KEY=sk_... to your .env file'
       );
     }
   }


### PR DESCRIPTION
## Summary
This PR adds a `--dry-run` flag to the `deploy` and `destroy` commands, allowing users to preview changes without making actual API calls. It also improves error messages for missing Stripe API keys across the codebase with clearer, actionable guidance.

## Key Changes

- **Added `--dry-run` flag to deploy command**: Previews resources that would be created/updated with their properties without making API calls
- **Added `--dry-run` flag to destroy command**: Shows resources that would be destroyed without making API calls
- **Improved confirmation flow in destroy command**: Replaced simple message with interactive `ux.confirm()` prompt when `--force` flag is not used
- **Enhanced error messages**: Standardized and improved Stripe API key error messages across `deploy.ts`, `destroy.ts`, and `stack.ts` with three actionable solutions:
  1. Setting the environment variable
  2. Passing it in the Stack constructor
  3. Adding it to a .env file
- **Updated imports**: Added `ux` import from `@oclif/core` in destroy command for interactive prompts

## Implementation Details

- Dry-run output uses color-coded formatting (cyan for headers, green for deploy resources, red for destroy resources)
- Dry-run displays stack ID, resource count, resource paths with types, and a summary
- Deploy dry-run additionally shows resource properties in formatted JSON
- Error messages are now consistent across all three files with the same helpful guidance text

https://claude.ai/code/session_01QDPm9GJmDC2YqF1kdrCpYr