### PR TITLE
Improve type safety in Stripe utilities and error handling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,10 +9,12 @@ workflows:
       - node/run:
           name: lint
           pkg-manager: pnpm
+          pnpm-version: '10.29.3'
           pnpm-run: lint
       - node/test:
           name: test-node-18
           pkg-manager: pnpm
+          pnpm-version: '10.29.3'
           executor:
             name: node/default
             tag: '18.20'
@@ -22,6 +24,7 @@ workflows:
       - node/test:
           name: test-node-20
           pkg-manager: pnpm
+          pnpm-version: '10.29.3'
           executor:
             name: node/default
             tag: '20.11'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,25 +9,34 @@ workflows:
       - node/run:
           name: lint
           pkg-manager: pnpm
-          pnpm-version: '10.29.3'
           pnpm-run: lint
+          setup:
+            - run:
+                name: Install pnpm via corepack
+                command: corepack enable && corepack prepare --activate
       - node/test:
           name: test-node-18
           pkg-manager: pnpm
-          pnpm-version: '10.29.3'
           executor:
             name: node/default
             tag: '18.20'
+          setup:
+            - run:
+                name: Install pnpm via corepack
+                command: corepack enable && corepack prepare --activate
           post_install_steps:
             - run: pnpm build
           test-results-for: jest
       - node/test:
           name: test-node-20
           pkg-manager: pnpm
-          pnpm-version: '10.29.3'
           executor:
             name: node/default
             tag: '20.11'
+          setup:
+            - run:
+                name: Install pnpm via corepack
+                command: corepack enable && corepack prepare --activate
           post_install_steps:
             - run: pnpm build
           test-results-for: jest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,9 +11,8 @@ workflows:
           pkg-manager: pnpm
           pnpm-run: lint
           setup:
-            - run:
-                name: Install pnpm via corepack
-                command: corepack enable && corepack prepare --activate
+            - node/install-pnpm:
+                version: '10.29.3'
       - node/test:
           name: test-node-18
           pkg-manager: pnpm
@@ -21,9 +20,8 @@ workflows:
             name: node/default
             tag: '18.20'
           setup:
-            - run:
-                name: Install pnpm via corepack
-                command: corepack enable && corepack prepare --activate
+            - node/install-pnpm:
+                version: '10.29.3'
           post_install_steps:
             - run: pnpm build
           test-results-for: jest
@@ -34,9 +32,8 @@ workflows:
             name: node/default
             tag: '20.11'
           setup:
-            - run:
-                name: Install pnpm via corepack
-                command: corepack enable && corepack prepare --activate
+            - node/install-pnpm:
+                version: '10.29.3'
           post_install_steps:
             - run: pnpm build
           test-results-for: jest

--- a/packages/cli/src/__tests__/deployer.test.ts
+++ b/packages/cli/src/__tests__/deployer.test.ts
@@ -265,7 +265,7 @@ describe('StripeDeployer', () => {
     describe('Coupon', () => {
       it('新規Couponを作成する（resource_missingエラー時）', async () => {
         const notFoundError = new Error('No such coupon');
-        (notFoundError as any).code = 'resource_missing';
+        Object.assign(notFoundError, { code: 'resource_missing' });
         mockStripeInstance.coupons.retrieve.mockRejectedValue(notFoundError);
         mockStripeInstance.coupons.create.mockResolvedValue({
           id: 'SUMMER20',
@@ -536,7 +536,7 @@ describe('StripeDeployer', () => {
 
     it('存在しないCouponの削除はスキップされる', async () => {
       const notFoundError = new Error('No such coupon');
-      (notFoundError as any).code = 'resource_missing';
+      Object.assign(notFoundError, { code: 'resource_missing' });
       mockStripeInstance.coupons.del.mockRejectedValue(notFoundError);
 
       const manifest: StackManifest = {

--- a/packages/cli/src/engine/stripe-utils.ts
+++ b/packages/cli/src/engine/stripe-utils.ts
@@ -12,7 +12,7 @@ export function escapeSearchQuery(id: string): string {
  * Strip internal metadata keys (pricectl_id, pricectl_path, fillet_id, fillet_path)
  * and return undefined if no user-defined metadata remains.
  */
-function stripInternalMetadata(metadata: Record<string, any> | undefined): Record<string, any> | undefined {
+function stripInternalMetadata(metadata: Record<string, string> | null | undefined): Record<string, string> | undefined {
   if (!metadata) return undefined;
   const { pricectl_id: _pid, pricectl_path: _ppath, fillet_id: _fid, fillet_path: _fpath, ...userMetadata } = metadata;
   return Object.keys(userMetadata).length > 0 ? userMetadata : undefined;
@@ -30,8 +30,8 @@ export async function findExistingProduct(stripe: Stripe, logicalId: string): Pr
       limit: 1,
     });
     return result.data.length > 0 ? result.data[0] : null;
-  } catch (error: any) {
-    if (error.code === 'resource_missing') {
+  } catch (error: unknown) {
+    if (error instanceof Stripe.errors.StripeError && error.code === 'resource_missing') {
       return null;
     }
     throw error;
@@ -50,8 +50,8 @@ export async function findExistingPrice(stripe: Stripe, logicalId: string): Prom
       limit: 1,
     });
     return result.data.length > 0 ? result.data[0] : null;
-  } catch (error: any) {
-    if (error.code === 'resource_missing') {
+  } catch (error: unknown) {
+    if (error instanceof Stripe.errors.StripeError && error.code === 'resource_missing') {
       return null;
     }
     throw error;
@@ -62,7 +62,7 @@ export async function findExistingPrice(stripe: Stripe, logicalId: string): Prom
  * Fetch the current state of any resource from Stripe.
  * Uses the Search API for Products and Prices, and direct retrieval for Coupons.
  */
-export async function fetchCurrentResource(stripe: Stripe, resource: any): Promise<any> {
+export async function fetchCurrentResource(stripe: Stripe, resource: { type: string; id: string }): Promise<Stripe.Product | Stripe.Price | Stripe.Coupon | null> {
   try {
     switch (resource.type) {
       case 'Stripe::Product':
@@ -74,8 +74,8 @@ export async function fetchCurrentResource(stripe: Stripe, resource: any): Promi
       default:
         throw new Error(`Unsupported resource type: ${resource.type}`);
     }
-  } catch (error: any) {
-    if (error.code === 'resource_missing') {
+  } catch (error: unknown) {
+    if (error instanceof Stripe.errors.StripeError && error.code === 'resource_missing') {
       return null;
     }
     throw error;
@@ -87,23 +87,24 @@ export async function fetchCurrentResource(stripe: Stripe, resource: any): Promi
  * Strips internal metadata keys and retains only user-configurable properties
  * to enable accurate comparison between desired and current state.
  */
-export function normalizeResource(resource: any, resourceType: string): any {
-  const normalized: any = {};
+export function normalizeResource(resource: Stripe.Product | Stripe.Price | Stripe.Coupon, resourceType: string): Record<string, unknown> {
+  const normalized: Record<string, unknown> = {};
 
   switch (resourceType) {
     case 'Stripe::Product': {
-      if (resource.name !== undefined) normalized.name = resource.name;
-      if (resource.description !== undefined) normalized.description = resource.description;
-      if (resource.active !== undefined) normalized.active = resource.active;
-      if (resource.images) normalized.images = resource.images;
-      if (resource.url !== undefined) normalized.url = resource.url;
-      if (resource.unit_label !== undefined) normalized.unit_label = resource.unit_label;
-      if (resource.statement_descriptor !== undefined) {
-        normalized.statement_descriptor = resource.statement_descriptor;
+      const r = resource as Stripe.Product;
+      if (r.name !== undefined) normalized.name = r.name;
+      if (r.description !== undefined) normalized.description = r.description;
+      if (r.active !== undefined) normalized.active = r.active;
+      if (r.images) normalized.images = r.images;
+      if (r.url !== undefined) normalized.url = r.url;
+      if (r.unit_label !== undefined) normalized.unit_label = r.unit_label;
+      if (r.statement_descriptor !== undefined) {
+        normalized.statement_descriptor = r.statement_descriptor;
       }
-      if (resource.tax_code !== undefined) normalized.tax_code = resource.tax_code;
+      if (r.tax_code !== undefined) normalized.tax_code = r.tax_code;
       // Exclude pricectl and legacy fillet metadata from comparison
-      const productMetadata = stripInternalMetadata(resource.metadata);
+      const productMetadata = stripInternalMetadata(r.metadata);
       if (productMetadata) {
         normalized.metadata = productMetadata;
       }
@@ -111,50 +112,52 @@ export function normalizeResource(resource: any, resourceType: string): any {
     }
 
     case 'Stripe::Price': {
-      if (resource.product !== undefined) normalized.product = resource.product;
-      if (resource.currency !== undefined) normalized.currency = resource.currency;
-      if (resource.unit_amount !== undefined) normalized.unit_amount = resource.unit_amount;
-      if (resource.unit_amount_decimal !== undefined) {
-        normalized.unit_amount_decimal = resource.unit_amount_decimal;
+      const r = resource as Stripe.Price;
+      if (r.product !== undefined) normalized.product = r.product;
+      if (r.currency !== undefined) normalized.currency = r.currency;
+      if (r.unit_amount !== undefined) normalized.unit_amount = r.unit_amount;
+      if (r.unit_amount_decimal !== undefined) {
+        normalized.unit_amount_decimal = r.unit_amount_decimal;
       }
-      if (resource.active !== undefined) normalized.active = resource.active;
-      if (resource.nickname !== undefined) normalized.nickname = resource.nickname;
-      if (resource.lookup_key !== undefined) normalized.lookup_key = resource.lookup_key;
+      if (r.active !== undefined) normalized.active = r.active;
+      if (r.nickname !== undefined) normalized.nickname = r.nickname;
+      if (r.lookup_key !== undefined) normalized.lookup_key = r.lookup_key;
 
-      if (resource.recurring) {
-        normalized.recurring = {};
-        if (resource.recurring.interval !== undefined) {
-          normalized.recurring.interval = resource.recurring.interval;
+      if (r.recurring) {
+        const rec: Record<string, unknown> = {};
+        if (r.recurring.interval !== undefined) {
+          rec.interval = r.recurring.interval;
         }
-        if (resource.recurring.interval_count !== undefined) {
-          normalized.recurring.interval_count = resource.recurring.interval_count;
+        if (r.recurring.interval_count !== undefined) {
+          rec.interval_count = r.recurring.interval_count;
         }
-        if (resource.recurring.usage_type !== undefined) {
-          normalized.recurring.usage_type = resource.recurring.usage_type;
+        if (r.recurring.usage_type !== undefined) {
+          rec.usage_type = r.recurring.usage_type;
         }
-        if (resource.recurring.trial_period_days !== undefined) {
-          normalized.recurring.trial_period_days = resource.recurring.trial_period_days;
+        if (r.recurring.trial_period_days !== undefined) {
+          rec.trial_period_days = r.recurring.trial_period_days;
         }
+        normalized.recurring = rec;
       }
 
-      if (resource.tiers_mode !== undefined) normalized.tiers_mode = resource.tiers_mode;
-      if (resource.tiers) {
-        normalized.tiers = resource.tiers.map((tier: any) => ({
+      if (r.tiers_mode !== undefined) normalized.tiers_mode = r.tiers_mode;
+      if (r.tiers) {
+        normalized.tiers = r.tiers.map((tier) => ({
           up_to: tier.up_to,
           unit_amount: tier.unit_amount,
           flat_amount: tier.flat_amount,
         }));
       }
 
-      if (resource.transform_quantity) {
+      if (r.transform_quantity) {
         normalized.transform_quantity = {
-          divide_by: resource.transform_quantity.divide_by,
-          round: resource.transform_quantity.round,
+          divide_by: r.transform_quantity.divide_by,
+          round: r.transform_quantity.round,
         };
       }
 
       // Exclude pricectl and legacy fillet metadata from comparison
-      const priceMetadata = stripInternalMetadata(resource.metadata);
+      const priceMetadata = stripInternalMetadata(r.metadata);
       if (priceMetadata) {
         normalized.metadata = priceMetadata;
       }
@@ -162,20 +165,21 @@ export function normalizeResource(resource: any, resourceType: string): any {
     }
 
     case 'Stripe::Coupon': {
-      if (resource.duration !== undefined) normalized.duration = resource.duration;
-      if (resource.amount_off !== undefined) normalized.amount_off = resource.amount_off;
-      if (resource.currency !== undefined) normalized.currency = resource.currency;
-      if (resource.percent_off !== undefined) normalized.percent_off = resource.percent_off;
-      if (resource.duration_in_months !== undefined) {
-        normalized.duration_in_months = resource.duration_in_months;
+      const r = resource as Stripe.Coupon;
+      if (r.duration !== undefined) normalized.duration = r.duration;
+      if (r.amount_off !== undefined) normalized.amount_off = r.amount_off;
+      if (r.currency !== undefined) normalized.currency = r.currency;
+      if (r.percent_off !== undefined) normalized.percent_off = r.percent_off;
+      if (r.duration_in_months !== undefined) {
+        normalized.duration_in_months = r.duration_in_months;
       }
-      if (resource.max_redemptions !== undefined) {
-        normalized.max_redemptions = resource.max_redemptions;
+      if (r.max_redemptions !== undefined) {
+        normalized.max_redemptions = r.max_redemptions;
       }
-      if (resource.name !== undefined) normalized.name = resource.name;
-      if (resource.redeem_by !== undefined) normalized.redeem_by = resource.redeem_by;
-      if (resource.applies_to !== undefined) normalized.applies_to = resource.applies_to;
-      const couponMetadata = stripInternalMetadata(resource.metadata);
+      if (r.name !== undefined) normalized.name = r.name;
+      if (r.redeem_by !== undefined) normalized.redeem_by = r.redeem_by;
+      if (r.applies_to !== undefined) normalized.applies_to = r.applies_to;
+      const couponMetadata = stripInternalMetadata(r.metadata);
       if (couponMetadata) {
         normalized.metadata = couponMetadata;
       }

--- a/packages/constructs/src/price.ts
+++ b/packages/constructs/src/price.ts
@@ -201,7 +201,7 @@ export class Price extends Resource {
       // When tiers are present, billing_scheme must be 'tiered'
       params.billing_scheme = 'tiered';
       params.tiers = this.tiers.map(tier => {
-        const tierObj: any = {
+        const tierObj: Stripe.PriceCreateParams.Tier = {
           up_to: tier.upTo,
           unit_amount: tier.unitAmount,
         };

--- a/packages/core/src/__tests__/stack.test.ts
+++ b/packages/core/src/__tests__/stack.test.ts
@@ -1,4 +1,5 @@
 import { Construct } from '../construct';
+import { STRIPE_API_KEY_MISSING_ERROR } from '../errors';
 import { Stack } from '../stack';
 import { TestResource } from './helpers';
 
@@ -58,7 +59,7 @@ describe('Stack', () => {
         delete process.env.STRIPE_SECRET_KEY;
 
         expect(() => new Stack(undefined, 'TestStack')).toThrow(
-          'Stripe API key is required'
+          STRIPE_API_KEY_MISSING_ERROR
         );
       } finally {
         if (original !== undefined) {


### PR DESCRIPTION
## Summary
This PR improves type safety throughout the codebase by replacing loose `any` types with proper TypeScript types, enhancing error handling with type guards, and using type assertions where appropriate.

## Key Changes

- **Stripe utility type improvements** (`stripe-utils.ts`):
  - Changed `stripInternalMetadata()` to accept `Record<string, string> | null | undefined` instead of `Record<string, any> | undefined`
  - Updated `fetchCurrentResource()` parameter and return types to use specific Stripe types (`Stripe.Product | Stripe.Price | Stripe.Coupon | null`) instead of `any`
  - Improved `normalizeResource()` to accept union of specific Stripe resource types and return `Record<string, unknown>` instead of `any`
  - Added type assertions (`as Stripe.Product`, `as Stripe.Price`, `as Stripe.Coupon`) within switch cases for proper type narrowing

- **Error handling improvements**:
  - Changed all `catch (error: any)` to `catch (error: unknown)` following TypeScript best practices
  - Added type guards using `error instanceof Stripe.errors.StripeError` before accessing error properties
  - Updated test files to use `Object.assign()` instead of type casting for error property assignment

- **Other type refinements**:
  - Fixed `Price` construct to use `Stripe.PriceCreateParams.Tier` type instead of `any` for tier objects
  - Updated test imports to use error constant `STRIPE_API_KEY_MISSING_ERROR` instead of string literal
  - Pinned pnpm version to `10.29.3` in CircleCI configuration for consistency

## Implementation Details
The changes maintain backward compatibility while improving type safety. Type assertions are used strategically within switch statements to help TypeScript understand resource types after narrowing, and proper type guards are applied before accessing error properties to prevent runtime errors.

https://claude.ai/code/session_01Cs5zGJC4wxWK7iiHmgeE3S