### PR TITLE
Add Node.js 22 test configuration to CI pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ workflows:
           pkg-manager: pnpm
           executor:
             name: node/default
-            tag: '22'
+            tag: '22.13'
           setup:
             - node/install-pnpm:
                 version: '10.29.3'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,3 +37,15 @@ workflows:
           post_install_steps:
             - run: pnpm build
           test-results-for: jest
+      - node/test:
+          name: test-node-22
+          pkg-manager: pnpm
+          executor:
+            name: node/default
+            tag: '22'
+          setup:
+            - node/install-pnpm:
+                version: '10.29.3'
+          post_install_steps:
+            - run: pnpm build
+          test-results-for: jest


### PR DESCRIPTION
## Summary
Added a new test job to the CircleCI configuration to run tests against Node.js 22, ensuring compatibility with the latest Node.js LTS version.

## Key Changes
- Added `test-node-22` job to the CI workflow that mirrors the existing Node.js test configuration
- Configured the job to use Node.js 22 with pnpm 10.29.3 as the package manager
- Included the same build and test steps as other Node.js versions (build step and jest test results collection)

## Implementation Details
The new job follows the same pattern as existing Node.js version tests in the workflow, using the CircleCI `node/test` orb with:
- Node.js 22 executor
- pnpm 10.29.3 installation
- Post-install build step via `pnpm build`
- Jest test result reporting

https://claude.ai/code/session_01RpAvvcw8gWrvfP9Gh1KpGt