### PR TITLE
Add tax_behavior support to Stripe Price resource

### DIFF
--- a/packages/constructs/src/__tests__/price.test.ts
+++ b/packages/constructs/src/__tests__/price.test.ts
@@ -175,10 +175,26 @@ describe('Price', () => {
       expect(props).not.toHaveProperty('recurring');
       expect(props).not.toHaveProperty('metadata');
       expect(props).not.toHaveProperty('lookup_key');
+      expect(props).not.toHaveProperty('tax_behavior');
       expect(props).not.toHaveProperty('tiers');
       expect(props).not.toHaveProperty('tiers_mode');
       expect(props).not.toHaveProperty('billing_scheme');
       expect(props).not.toHaveProperty('transform_quantity');
+    });
+
+    it('taxBehaviorがsnake_caseで含まれる', () => {
+      const stack = createStack();
+      new Price(stack, 'ExclusivePrice', {
+        product: 'prod_123',
+        currency: 'usd',
+        unitAmount: 1000,
+        taxBehavior: 'exclusive',
+      });
+
+      const manifest = stack.synth();
+      const props = manifest.resources.find(r => r.id === 'ExclusivePrice')!.properties;
+
+      expect(props.tax_behavior).toBe('exclusive');
     });
 
     it('nicknameとlookupKeyが含まれる', () => {

--- a/packages/constructs/src/price.ts
+++ b/packages/constructs/src/price.ts
@@ -78,6 +78,12 @@ export interface PriceProps extends ResourceProps {
   readonly type?: 'one_time' | 'recurring';
 
   /**
+   * Specifies whether the price is considered inclusive of taxes or exclusive of taxes.
+   * One of inclusive, exclusive, or unspecified.
+   */
+  readonly taxBehavior?: 'inclusive' | 'exclusive' | 'unspecified';
+
+  /**
    * Apply a transformation to the reported usage or set quantity before computing the billed price.
    */
   readonly transformQuantity?: {
@@ -134,6 +140,7 @@ export class Price extends Resource {
     divideBy: number;
     round: 'up' | 'down';
   };
+  public readonly taxBehavior?: 'inclusive' | 'exclusive' | 'unspecified';
   public readonly tiersMode?: 'graduated' | 'volume';
   public readonly tiers?: Array<{
     upTo: number | 'inf';
@@ -154,6 +161,7 @@ export class Price extends Resource {
     this.metadata = props.metadata;
     this.lookupKey = props.lookupKey;
     this.type = props.type;
+    this.taxBehavior = props.taxBehavior;
     this.transformQuantity = props.transformQuantity;
     this.tiersMode = props.tiersMode;
     this.tiers = props.tiers;
@@ -178,6 +186,7 @@ export class Price extends Resource {
     if (this.nickname !== undefined) params.nickname = this.nickname;
     if (this.metadata !== undefined) params.metadata = this.metadata;
     if (this.lookupKey !== undefined) params.lookup_key = this.lookupKey;
+    if (this.taxBehavior !== undefined) params.tax_behavior = this.taxBehavior;
     if (this.tiersMode !== undefined) params.tiers_mode = this.tiersMode;
 
     // Transform quantity - convert camelCase to snake_case for Stripe API


### PR DESCRIPTION
## Summary
This PR adds support for the `taxBehavior` property to the Stripe Price construct, allowing users to specify whether a price is inclusive or exclusive of taxes.

## Key Changes
- **Price construct** (`packages/constructs/src/price.ts`):
  - Added `taxBehavior` property to `PriceProps` interface with type `'inclusive' | 'exclusive' | 'unspecified'`
  - Added `taxBehavior` as a public readonly property on the `Price` class
  - Added initialization of `taxBehavior` in the constructor
  - Added conversion of `taxBehavior` to `tax_behavior` (snake_case) in the `toJSON()` method for Stripe API compatibility

- **Price construct tests** (`packages/constructs/src/__tests__/price.test.ts`):
  - Added test to verify `taxBehavior` is converted to snake_case (`tax_behavior`) in the manifest
  - Updated existing test to verify `tax_behavior` is not included when not specified

- **Deployer tests** (`packages/cli/src/__tests__/deployer.test.ts`):
  - Added test case: when `tax_behavior` differs between existing and desired price, the old price is deactivated and a new one is created
  - Added test case: when `tax_behavior` is the same, the price status is marked as `unchanged`

## Implementation Details
- The `taxBehavior` property follows the existing pattern of camelCase in TypeScript being converted to snake_case for the Stripe API
- When `tax_behavior` changes, the deployment strategy treats it as a breaking change, deactivating the old price and creating a new one (consistent with other immutable price properties)
- The property is optional and only included in API calls when explicitly specified

https://claude.ai/code/session_01H2eAY9Rrn9bKjCdbf9LEW1