### PR TITLE
Add repository metadata to package.json files

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,5 +36,10 @@
     "type": "git",
     "url": "git+https://github.com/hideokamoto/pricectl.git"
   },
+  "homepage": "https://github.com/hideokamoto/pricectl#readme",
+  "bugs": {
+    "url": "https://github.com/hideokamoto/pricectl/issues"
+  },
+  "author": "hideokamoto",
   "license": "MIT"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -18,6 +18,16 @@
     "lint": "eslint src --ext .ts"
   },
   "keywords": ["stripe", "iac", "cli"],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/hideokamoto/pricectl.git",
+    "directory": "packages/cli"
+  },
+  "homepage": "https://github.com/hideokamoto/pricectl/tree/master/packages/cli#readme",
+  "bugs": {
+    "url": "https://github.com/hideokamoto/pricectl/issues"
+  },
+  "author": "hideokamoto",
   "license": "MIT",
   "dependencies": {
     "@pricectl/core": "workspace:*",

--- a/packages/constructs/package.json
+++ b/packages/constructs/package.json
@@ -14,6 +14,16 @@
     "lint": "eslint src --ext .ts"
   },
   "keywords": ["stripe", "iac", "constructs"],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/hideokamoto/pricectl.git",
+    "directory": "packages/constructs"
+  },
+  "homepage": "https://github.com/hideokamoto/pricectl/tree/master/packages/constructs#readme",
+  "bugs": {
+    "url": "https://github.com/hideokamoto/pricectl/issues"
+  },
+  "author": "hideokamoto",
   "license": "MIT",
   "dependencies": {
     "@pricectl/core": "workspace:*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,6 +14,16 @@
     "lint": "eslint src --ext .ts"
   },
   "keywords": ["stripe", "iac", "infrastructure", "cdk"],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/hideokamoto/pricectl.git",
+    "directory": "packages/core"
+  },
+  "homepage": "https://github.com/hideokamoto/pricectl/tree/master/packages/core#readme",
+  "bugs": {
+    "url": "https://github.com/hideokamoto/pricectl/issues"
+  },
+  "author": "hideokamoto",
   "license": "MIT",
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
## Summary
This PR adds missing repository metadata fields to the root `package.json` and all workspace package files (`packages/cli`, `packages/constructs`, `packages/core`). This improves package discoverability and provides users with clear links to the project repository, homepage, and issue tracker.

## Changes
- Added `repository` field with git URL and directory paths to each workspace package
- Added `homepage` field pointing to the respective package directory in the GitHub repository
- Added `bugs` field with link to the GitHub issues page
- Added `author` field crediting hideokamoto
- Updated root `package.json` with `homepage`, `bugs`, and `author` fields

## Details
These metadata fields are standard npm package.json conventions that:
- Enable npm to display repository information on the package registry
- Help users find the source code and report issues
- Improve package management and discoverability
- Follow npm best practices for monorepo packages with the `directory` field in repository configuration

https://claude.ai/code/session_01N3Sw76FbkMRWWuNKsY63Vi