### PR TITLE
Add validation for Construct id and duplicate detection

### DIFF
--- a/packages/core/src/__tests__/construct.test.ts
+++ b/packages/core/src/__tests__/construct.test.ts
@@ -1,6 +1,36 @@
 import { Construct } from '../construct';
+import { DUPLICATE_LOGICAL_ID_ERROR, EMPTY_LOGICAL_ID_ERROR } from '../errors';
 
 describe('Construct', () => {
+  describe('バリデーション', () => {
+    it('空文字列のidはエラーになる', () => {
+      expect(() => new Construct(undefined, '')).toThrow(EMPTY_LOGICAL_ID_ERROR);
+    });
+
+    it('空白のみのidはエラーになる', () => {
+      expect(() => new Construct(undefined, '   ')).toThrow(EMPTY_LOGICAL_ID_ERROR);
+    });
+
+    it('同一スコープ内に同じidの子を追加するとエラーになる', () => {
+      const parent = new Construct(undefined, 'Parent');
+      new Construct(parent, 'Child');
+
+      expect(() => new Construct(parent, 'Child')).toThrow(
+        DUPLICATE_LOGICAL_ID_ERROR('Child', 'Parent')
+      );
+    });
+
+    it('異なるスコープ内では同じidを使用できる', () => {
+      const parent1 = new Construct(undefined, 'Parent1');
+      const parent2 = new Construct(undefined, 'Parent2');
+
+      expect(() => {
+        new Construct(parent1, 'Child');
+        new Construct(parent2, 'Child');
+      }).not.toThrow();
+    });
+  });
+
   describe('ルートConstruct（scopeなし）', () => {
     it('idが設定される', () => {
       const root = new Construct(undefined, 'Root');

--- a/packages/core/src/construct.ts
+++ b/packages/core/src/construct.ts
@@ -1,3 +1,5 @@
+import { DUPLICATE_LOGICAL_ID_ERROR, EMPTY_LOGICAL_ID_ERROR } from './errors';
+
 /**
  * Base class for all pricectl constructs.
  * Inspired by AWS CDK's Construct class.
@@ -43,6 +45,11 @@ export class ConstructNode {
   }
 
   public addChild(child: Construct): void {
+    const childId = child.node.id;
+    const existing = this._children.find((c) => c.node.id === childId);
+    if (existing) {
+      throw new Error(DUPLICATE_LOGICAL_ID_ERROR(childId, this.host.node.path));
+    }
     this._children.push(child);
   }
 
@@ -67,6 +74,10 @@ export class Construct implements IConstruct {
   public readonly node: ConstructNode;
 
   constructor(scope: Construct | undefined, id: string) {
+    if (id.trim() === '') {
+      throw new Error(EMPTY_LOGICAL_ID_ERROR);
+    }
+
     this.node = new ConstructNode(this, id, scope);
 
     if (scope) {

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -4,3 +4,11 @@ export const STRIPE_API_KEY_MISSING_ERROR =
   '  1. Set the environment variable:  export STRIPE_SECRET_KEY=sk_...\n' +
   '  2. Pass it in the Stack constructor: new Stack(scope, "id", { apiKey: "sk_..." })\n' +
   '  3. Add STRIPE_SECRET_KEY=sk_... to your .env file';
+
+export const EMPTY_LOGICAL_ID_ERROR =
+  'Construct id must not be an empty string. ' +
+  'Provide a unique non-empty identifier as the second argument.';
+
+export const DUPLICATE_LOGICAL_ID_ERROR = (id: string, path: string) =>
+  `There is already a child construct with id "${id}" under "${path}". ` +
+  'Each construct within the same scope must have a unique id.';


### PR DESCRIPTION
## Summary
This PR adds validation to the Construct class to ensure logical IDs are valid and unique within their scope. It introduces error handling for empty IDs and duplicate IDs in the same parent construct.

## Key Changes
- **ID Validation**: Added check in `Construct` constructor to reject empty or whitespace-only IDs with a clear error message
- **Duplicate Detection**: Implemented duplicate ID detection in `ConstructNode.addChild()` to prevent multiple children with the same ID under the same parent
- **Error Messages**: Added two new error constants (`EMPTY_LOGICAL_ID_ERROR` and `DUPLICATE_LOGICAL_ID_ERROR`) with descriptive messages to guide users
- **Test Coverage**: Added comprehensive test suite covering:
  - Empty string ID validation
  - Whitespace-only ID validation
  - Duplicate ID detection within the same scope
  - Allowing duplicate IDs across different scopes

## Implementation Details
- The validation occurs at construction time, preventing invalid constructs from being created
- Duplicate detection uses the construct's path (parent's path) to provide context in error messages
- The implementation maintains backward compatibility while adding stricter validation

https://claude.ai/code/session_019uSZh2tuq9krWzDsrVqqai