### PR TITLE
fix: protect apiKey from accidental exposure in logs

### DIFF
--- a/packages/core/src/__tests__/stack.test.ts
+++ b/packages/core/src/__tests__/stack.test.ts
@@ -53,6 +53,15 @@ describe('Stack', () => {
       }
     });
 
+    it('JSON.stringifyでapiKeyが出力されない', () => {
+      const stack = new Stack(undefined, 'TestStack', { apiKey: API_KEY });
+
+      const json = JSON.parse(JSON.stringify(stack));
+
+      expect(json.apiKey).toBeUndefined();
+      expect(JSON.stringify(stack)).not.toContain(API_KEY);
+    });
+
     it('apiKeyが未指定かつ環境変数もない場合はエラー', () => {
       const original = process.env.STRIPE_SECRET_KEY;
       try {

--- a/packages/core/src/stack.ts
+++ b/packages/core/src/stack.ts
@@ -29,22 +29,35 @@ export interface StackProps {
  * Similar to AWS CDK's Stack concept.
  */
 export class Stack extends Construct {
-  public readonly apiKey?: string;
+  private readonly _apiKey?: string;
   public readonly apiVersion?: string;
   public readonly description?: string;
   public readonly tags: Record<string, string>;
 
+  get apiKey(): string | undefined {
+    return this._apiKey;
+  }
+
   constructor(scope: Construct | undefined, id: string, props: StackProps = {}) {
     super(scope, id);
 
-    this.apiKey = props.apiKey || process.env.STRIPE_SECRET_KEY;
+    this._apiKey = props.apiKey || process.env.STRIPE_SECRET_KEY;
     this.apiVersion = props.apiVersion || '2024-12-18.acacia';
     this.description = props.description;
     this.tags = props.tags || {};
 
-    if (!this.apiKey) {
+    if (!this._apiKey) {
       throw new Error(STRIPE_API_KEY_MISSING_ERROR);
     }
+  }
+
+  toJSON(): object {
+    return {
+      id: this.node.id,
+      apiVersion: this.apiVersion,
+      description: this.description,
+      tags: this.tags,
+    };
   }
 
   /**


### PR DESCRIPTION
- Make `_apiKey` a private field with a public getter on `Stack`
- Override `toJSON()` to omit the API key from JSON serialization,
  preventing it from appearing in `console.log(stack)` or error output
- Add test asserting `JSON.stringify(stack)` never contains the key value

https://claude.ai/code/session_01P3GLppfJeSNSY6tVw6Vxak