### PR TITLE
fix: normalize null/undefined handling and add decimal tier fields in normalizeResource

### DIFF
--- a/packages/cli/src/engine/stripe-utils.ts
+++ b/packages/cli/src/engine/stripe-utils.ts
@@ -158,16 +158,16 @@ export function normalizeResource(resource: Stripe.Product | Stripe.Price | Stri
   switch (resourceType) {
     case 'Stripe::Product': {
       const r = resource as Stripe.Product;
-      if (r.name !== undefined) normalized.name = r.name;
-      if (r.description !== undefined) normalized.description = r.description;
-      if (r.active !== undefined) normalized.active = r.active;
-      if (r.images) normalized.images = r.images;
-      if (r.url !== undefined) normalized.url = r.url;
-      if (r.unit_label !== undefined) normalized.unit_label = r.unit_label;
-      if (r.statement_descriptor !== undefined) {
+      if (r.name != null) normalized.name = r.name;
+      if (r.description != null) normalized.description = r.description;
+      if (r.active != null) normalized.active = r.active;
+      if (r.images != null) normalized.images = r.images;
+      if (r.url != null) normalized.url = r.url;
+      if (r.unit_label != null) normalized.unit_label = r.unit_label;
+      if (r.statement_descriptor != null) {
         normalized.statement_descriptor = r.statement_descriptor;
       }
-      if (r.tax_code !== undefined) normalized.tax_code = r.tax_code;
+      if (r.tax_code != null) normalized.tax_code = r.tax_code;
       // Exclude pricectl and legacy fillet metadata from comparison
       const productMetadata = stripInternalMetadata(r.metadata);
       if (productMetadata) {
@@ -210,7 +210,9 @@ export function normalizeResource(resource: Stripe.Product | Stripe.Price | Stri
         normalized.tiers = r.tiers.map((tier) => ({
           up_to: tier.up_to,
           unit_amount: tier.unit_amount,
+          unit_amount_decimal: tier.unit_amount_decimal,
           flat_amount: tier.flat_amount,
+          flat_amount_decimal: tier.flat_amount_decimal,
         }));
       }
 


### PR DESCRIPTION
- Update Product section to use != null (excludes both null and undefined) instead of
  !== undefined (excludes only undefined), preventing false-positive diffs when Stripe
  API returns null for optional Product fields
- Add unit_amount_decimal and flat_amount_decimal to Price tier normalization, which
  were present in the old diff.ts implementation but missing from stripe-utils.ts

The consolidation of normalizeResource into stripe-utils.ts (called from diff.ts) was
already done, but the stripe-utils.ts implementation retained the weaker null checks
and was missing the decimal tier fields from the newer diff.ts version.

https://claude.ai/code/session_01WeAZ81L2acVmwzSd3zzQ4g