### PR TITLE
fix: remove unimplemented features from README overview and add them to roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ## Overview
 
-pricectl is an Infrastructure as Code (IaC) tool for Stripe pricing resources. Inspired by kubectl and AWS CDK, it allows you to define your pricing infrastructure (products, prices, coupons) using TypeScript and deploy them with simple CLI commands.
+pricectl is an Infrastructure as Code (IaC) tool for Stripe pricing resources. Inspired by kubectl and AWS CDK, it allows you to define your pricing infrastructure (products, prices, coupons, entitlements, meters) using TypeScript and deploy them with simple CLI commands.
 
 ### Why pricectl?
 
@@ -126,7 +126,9 @@ Stripe pricing resource implementations:
 - `Product`: Stripe products
 - `Price`: Pricing plans (one-time, recurring, tiered, metered)
 - `Coupon`: Discount coupons
-- Coming soon: Entitlements, Meters, PromotionCodes
+- `EntitlementFeature`: Entitlement features for access control
+- `Meter`: Billing meters for usage-based pricing
+- Coming soon: PromotionCodes
 
 ### 📦 `@pricectl/cli`
 
@@ -259,6 +261,46 @@ new Coupon(stack, 'Save10', {
 });
 ```
 
+### EntitlementFeature
+
+Define entitlement features for access control:
+
+```typescript
+new EntitlementFeature(stack, 'PremiumSupport', {
+  name: 'Premium Support',
+  lookupKey: 'premium-support',
+  metadata: { tier: 'premium' },
+});
+```
+
+### Meter
+
+Define billing meters for usage-based pricing:
+
+```typescript
+// Simple count-based meter
+new Meter(stack, 'ApiCalls', {
+  displayName: 'API Calls',
+  eventName: 'api_call',
+  defaultAggregation: {
+    formula: 'count',
+  },
+});
+
+// Sum-based meter with value settings
+new Meter(stack, 'DataTransfer', {
+  displayName: 'Data Transfer',
+  eventName: 'data_transfer',
+  defaultAggregation: {
+    formula: 'sum',
+  },
+  valueSettings: {
+    eventPayloadKey: 'bytes_used',
+  },
+  eventTimeWindow: 'hour',
+});
+```
+
 ## Examples
 
 Check out the [examples](./examples) directory for complete working examples:
@@ -322,8 +364,8 @@ pnpm test
 ## Roadmap
 
 ### v0.2.0
-- [ ] Entitlement resource
-- [ ] Meter resource
+- [x] Entitlement resource
+- [x] Meter resource
 - [ ] PromotionCode resource
 - [ ] Customer resource
 - [ ] Subscription resource

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ## Overview
 
-pricectl is an Infrastructure as Code (IaC) tool for Stripe pricing resources. Inspired by kubectl and AWS CDK, it allows you to define your pricing infrastructure (products, prices, coupons, entitlements, meters) using TypeScript and deploy them with simple CLI commands.
+pricectl is an Infrastructure as Code (IaC) tool for Stripe pricing resources. Inspired by kubectl and AWS CDK, it allows you to define your pricing infrastructure (products, prices, coupons, entitlement features, billing meters) using TypeScript and deploy them with simple CLI commands.
 
 ### Why pricectl?
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ## Overview
 
-pricectl is an Infrastructure as Code (IaC) tool for Stripe pricing resources. Inspired by kubectl and AWS CDK, it allows you to define your pricing infrastructure (products, prices, coupons, entitlements, meters) using TypeScript and deploy them with simple CLI commands.
+pricectl is an Infrastructure as Code (IaC) tool for Stripe pricing resources. Inspired by kubectl and AWS CDK, it allows you to define your pricing infrastructure (products, prices, coupons) using TypeScript and deploy them with simple CLI commands.
 
 ### Why pricectl?
 
@@ -322,6 +322,9 @@ pnpm test
 ## Roadmap
 
 ### v0.2.0
+- [ ] Entitlement resource
+- [ ] Meter resource
+- [ ] PromotionCode resource
 - [ ] Customer resource
 - [ ] Subscription resource
 - [ ] PaymentLink resource

--- a/packages/cli/src/engine/stripe-utils.ts
+++ b/packages/cli/src/engine/stripe-utils.ts
@@ -127,7 +127,7 @@ export async function fetchCurrentResource(
   resource: { type: string; id: string },
   stateManager?: StateManager,
   stackId?: string,
-): Promise<Stripe.Product | Stripe.Price | Stripe.Coupon | null> {
+): Promise<Stripe.Product | Stripe.Price | Stripe.Coupon | Stripe.Entitlements.Feature | Stripe.Billing.Meter | null> {
   try {
     switch (resource.type) {
       case 'Stripe::Product':
@@ -136,6 +136,14 @@ export async function fetchCurrentResource(
         return findExistingPrice(stripe, resource.id, stateManager, stackId);
       case 'Stripe::Coupon':
         return await stripe.coupons.retrieve(resource.id);
+      case 'Stripe::EntitlementFeature': {
+        const features = await stripe.entitlements.features.list({ limit: 100 });
+        return features.data.find(f => f.metadata?.pricectl_id === resource.id) ?? null;
+      }
+      case 'Stripe::BillingMeter': {
+        const meters = await stripe.billing.meters.list({ limit: 100 });
+        return meters.data.find(m => m.event_name === resource.id) ?? null;
+      }
       default:
         throw new Error(`Unsupported resource type: ${resource.type}`);
     }
@@ -152,7 +160,7 @@ export async function fetchCurrentResource(
  * Strips internal metadata keys and retains only user-configurable properties
  * to enable accurate comparison between desired and current state.
  */
-export function normalizeResource(resource: Stripe.Product | Stripe.Price | Stripe.Coupon, resourceType: string): Record<string, unknown> {
+export function normalizeResource(resource: Stripe.Product | Stripe.Price | Stripe.Coupon | Stripe.Entitlements.Feature | Stripe.Billing.Meter, resourceType: string): Record<string, unknown> {
   const normalized: Record<string, unknown> = {};
 
   switch (resourceType) {
@@ -247,6 +255,43 @@ export function normalizeResource(resource: Stripe.Product | Stripe.Price | Stri
       const couponMetadata = stripInternalMetadata(r.metadata);
       if (couponMetadata) {
         normalized.metadata = couponMetadata;
+      }
+      break;
+    }
+
+    case 'Stripe::EntitlementFeature': {
+      const r = resource as Stripe.Entitlements.Feature;
+      if (r.name !== undefined) normalized.name = r.name;
+      if (r.lookup_key !== undefined) normalized.lookup_key = r.lookup_key;
+      const featureMetadata = stripInternalMetadata(r.metadata);
+      if (featureMetadata) {
+        normalized.metadata = featureMetadata;
+      }
+      break;
+    }
+
+    case 'Stripe::BillingMeter': {
+      const r = resource as Stripe.Billing.Meter;
+      if (r.display_name !== undefined) normalized.display_name = r.display_name;
+      if (r.event_name !== undefined) normalized.event_name = r.event_name;
+      if (r.default_aggregation !== undefined) {
+        normalized.default_aggregation = {
+          formula: r.default_aggregation.formula,
+        };
+      }
+      if (r.customer_mapping !== undefined) {
+        normalized.customer_mapping = {
+          event_payload_key: r.customer_mapping.event_payload_key,
+          type: r.customer_mapping.type,
+        };
+      }
+      if (r.event_time_window !== undefined) {
+        normalized.event_time_window = r.event_time_window;
+      }
+      if (r.value_settings !== undefined) {
+        normalized.value_settings = {
+          event_payload_key: r.value_settings.event_payload_key,
+        };
       }
       break;
     }

--- a/packages/constructs/src/__tests__/entitlement.test.ts
+++ b/packages/constructs/src/__tests__/entitlement.test.ts
@@ -1,0 +1,111 @@
+import { EntitlementFeature } from '../entitlement';
+import { createStack } from './helpers';
+
+describe('EntitlementFeature', () => {
+
+  describe('プロパティの設定', () => {
+    it('必須プロパティのみで生成できる', () => {
+      const stack = createStack();
+      const feature = new EntitlementFeature(stack, 'PremiumSupport', {
+        name: 'Premium Support',
+        lookupKey: 'premium-support',
+      });
+
+      expect(feature.name).toBe('Premium Support');
+      expect(feature.lookupKey).toBe('premium-support');
+    });
+
+    it('すべてのオプショナルプロパティを設定できる', () => {
+      const stack = createStack();
+      const feature = new EntitlementFeature(stack, 'FullFeature', {
+        name: 'Full Feature',
+        lookupKey: 'full-feature',
+        metadata: { tier: 'enterprise' },
+      });
+
+      expect(feature.metadata).toEqual({ tier: 'enterprise' });
+    });
+  });
+
+  describe('synthesizeProperties（synth経由）', () => {
+    it('必須プロパティのみの場合', () => {
+      const stack = createStack();
+      new EntitlementFeature(stack, 'Feature1', {
+        name: 'API Access',
+        lookupKey: 'api-access',
+      });
+
+      const manifest = stack.synth();
+
+      expect(manifest.resources).toHaveLength(1);
+      expect(manifest.resources[0].type).toBe('Stripe::EntitlementFeature');
+      expect(manifest.resources[0].properties).toEqual({
+        name: 'API Access',
+        lookup_key: 'api-access',
+      });
+    });
+
+    it('metadataがpropertiesに含まれる', () => {
+      const stack = createStack();
+      new EntitlementFeature(stack, 'Feature2', {
+        name: 'Dashboard Access',
+        lookupKey: 'dashboard-access',
+        metadata: { category: 'core' },
+      });
+
+      const manifest = stack.synth();
+      const props = manifest.resources[0].properties;
+
+      expect(props.metadata).toEqual({ category: 'core' });
+    });
+
+    it('未指定のオプショナルプロパティはpropertiesに含まれない', () => {
+      const stack = createStack();
+      new EntitlementFeature(stack, 'Minimal', {
+        name: 'Minimal',
+        lookupKey: 'minimal',
+      });
+
+      const manifest = stack.synth();
+      const props = manifest.resources[0].properties;
+
+      expect(props).not.toHaveProperty('metadata');
+    });
+  });
+
+  describe('resourceType', () => {
+    it('Stripe::EntitlementFeatureを返す', () => {
+      const stack = createStack();
+      new EntitlementFeature(stack, 'MyFeature', {
+        name: 'My Feature',
+        lookupKey: 'my-feature',
+      });
+
+      const manifest = stack.synth();
+
+      expect(manifest.resources[0].type).toBe('Stripe::EntitlementFeature');
+    });
+  });
+
+  describe('Constructツリーとの統合', () => {
+    it('Stackの子として登録される', () => {
+      const stack = createStack();
+      const feature = new EntitlementFeature(stack, 'Feature1', {
+        name: 'Feature',
+        lookupKey: 'feature',
+      });
+
+      expect(stack.node.children).toContain(feature);
+    });
+
+    it('pathがStack/EntitlementFeatureの形式', () => {
+      const stack = createStack();
+      const feature = new EntitlementFeature(stack, 'MyFeature', {
+        name: 'Feature',
+        lookupKey: 'feature',
+      });
+
+      expect(feature.node.path).toBe('TestStack/MyFeature');
+    });
+  });
+});

--- a/packages/constructs/src/__tests__/meter.test.ts
+++ b/packages/constructs/src/__tests__/meter.test.ts
@@ -1,0 +1,183 @@
+import { Meter } from '../meter';
+import { createStack } from './helpers';
+
+describe('Meter', () => {
+
+  describe('プロパティの設定', () => {
+    it('必須プロパティのみで生成できる', () => {
+      const stack = createStack();
+      const meter = new Meter(stack, 'ApiCalls', {
+        displayName: 'API Calls',
+        eventName: 'api_call',
+        defaultAggregation: { formula: 'count' },
+      });
+
+      expect(meter.displayName).toBe('API Calls');
+      expect(meter.eventName).toBe('api_call');
+      expect(meter.defaultAggregation).toEqual({ formula: 'count' });
+    });
+
+    it('sumアグリゲーションを設定できる', () => {
+      const stack = createStack();
+      const meter = new Meter(stack, 'DataUsage', {
+        displayName: 'Data Usage',
+        eventName: 'data_transfer',
+        defaultAggregation: { formula: 'sum' },
+      });
+
+      expect(meter.defaultAggregation.formula).toBe('sum');
+    });
+
+    it('すべてのオプショナルプロパティを設定できる', () => {
+      const stack = createStack();
+      const meter = new Meter(stack, 'FullMeter', {
+        displayName: 'Full Meter',
+        eventName: 'full_event',
+        defaultAggregation: { formula: 'sum' },
+        customerMapping: {
+          eventPayloadKey: 'stripe_customer_id',
+          type: 'by_id',
+        },
+        eventTimeWindow: 'hour',
+        valueSettings: {
+          eventPayloadKey: 'bytes_used',
+        },
+      });
+
+      expect(meter.customerMapping).toEqual({
+        eventPayloadKey: 'stripe_customer_id',
+        type: 'by_id',
+      });
+      expect(meter.eventTimeWindow).toBe('hour');
+      expect(meter.valueSettings).toEqual({ eventPayloadKey: 'bytes_used' });
+    });
+  });
+
+  describe('synthesizeProperties（synth経由）', () => {
+    it('必須プロパティのみの場合', () => {
+      const stack = createStack();
+      new Meter(stack, 'Meter1', {
+        displayName: 'Request Count',
+        eventName: 'request',
+        defaultAggregation: { formula: 'count' },
+      });
+
+      const manifest = stack.synth();
+
+      expect(manifest.resources).toHaveLength(1);
+      expect(manifest.resources[0].type).toBe('Stripe::BillingMeter');
+      expect(manifest.resources[0].properties).toEqual({
+        display_name: 'Request Count',
+        event_name: 'request',
+        default_aggregation: { formula: 'count' },
+      });
+    });
+
+    it('customerMappingがsnake_caseに変換される', () => {
+      const stack = createStack();
+      new Meter(stack, 'Meter2', {
+        displayName: 'Meter',
+        eventName: 'event',
+        defaultAggregation: { formula: 'count' },
+        customerMapping: {
+          eventPayloadKey: 'customer_id',
+        },
+      });
+
+      const manifest = stack.synth();
+      const props = manifest.resources[0].properties;
+
+      expect(props.customer_mapping).toEqual({
+        event_payload_key: 'customer_id',
+        type: 'by_id',
+      });
+    });
+
+    it('eventTimeWindowがsnake_caseに変換される', () => {
+      const stack = createStack();
+      new Meter(stack, 'Meter3', {
+        displayName: 'Meter',
+        eventName: 'event',
+        defaultAggregation: { formula: 'count' },
+        eventTimeWindow: 'day',
+      });
+
+      const manifest = stack.synth();
+      const props = manifest.resources[0].properties;
+
+      expect(props.event_time_window).toBe('day');
+    });
+
+    it('valueSettingsがsnake_caseに変換される', () => {
+      const stack = createStack();
+      new Meter(stack, 'Meter4', {
+        displayName: 'Meter',
+        eventName: 'event',
+        defaultAggregation: { formula: 'sum' },
+        valueSettings: { eventPayloadKey: 'amount' },
+      });
+
+      const manifest = stack.synth();
+      const props = manifest.resources[0].properties;
+
+      expect(props.value_settings).toEqual({
+        event_payload_key: 'amount',
+      });
+    });
+
+    it('未指定のオプショナルプロパティはpropertiesに含まれない', () => {
+      const stack = createStack();
+      new Meter(stack, 'Minimal', {
+        displayName: 'Minimal',
+        eventName: 'event',
+        defaultAggregation: { formula: 'count' },
+      });
+
+      const manifest = stack.synth();
+      const props = manifest.resources[0].properties;
+
+      expect(props).not.toHaveProperty('customer_mapping');
+      expect(props).not.toHaveProperty('event_time_window');
+      expect(props).not.toHaveProperty('value_settings');
+    });
+  });
+
+  describe('resourceType', () => {
+    it('Stripe::BillingMeterを返す', () => {
+      const stack = createStack();
+      new Meter(stack, 'MyMeter', {
+        displayName: 'My Meter',
+        eventName: 'my_event',
+        defaultAggregation: { formula: 'count' },
+      });
+
+      const manifest = stack.synth();
+
+      expect(manifest.resources[0].type).toBe('Stripe::BillingMeter');
+    });
+  });
+
+  describe('Constructツリーとの統合', () => {
+    it('Stackの子として登録される', () => {
+      const stack = createStack();
+      const meter = new Meter(stack, 'Meter1', {
+        displayName: 'Meter',
+        eventName: 'event',
+        defaultAggregation: { formula: 'count' },
+      });
+
+      expect(stack.node.children).toContain(meter);
+    });
+
+    it('pathがStack/Meterの形式', () => {
+      const stack = createStack();
+      const meter = new Meter(stack, 'MyMeter', {
+        displayName: 'Meter',
+        eventName: 'event',
+        defaultAggregation: { formula: 'count' },
+      });
+
+      expect(meter.node.path).toBe('TestStack/MyMeter');
+    });
+  });
+});

--- a/packages/constructs/src/entitlement.ts
+++ b/packages/constructs/src/entitlement.ts
@@ -1,0 +1,66 @@
+import { Construct, Resource, ResourceProps } from '@pricectl/core';
+import type Stripe from 'stripe';
+
+export interface EntitlementFeatureProps extends ResourceProps {
+  /**
+   * The feature's name, for your own purpose, not meant to be displayable to the customer.
+   */
+  readonly name: string;
+
+  /**
+   * A unique key you provide as your own system identifier. This may be up to 80 characters.
+   */
+  readonly lookupKey: string;
+
+  /**
+   * Set of key-value pairs that you can attach to an object.
+   */
+  readonly metadata?: Record<string, string>;
+}
+
+/**
+ * Represents a Stripe Entitlements Feature
+ *
+ * A feature represents a monetizable ability or functionality in your system.
+ * Features can be assigned to products, and when those products are purchased,
+ * Stripe will create an entitlement to the feature for the purchasing customer.
+ *
+ * @example
+ * ```ts
+ * new EntitlementFeature(stack, 'PremiumSupport', {
+ *   name: 'Premium Support',
+ *   lookupKey: 'premium-support',
+ * });
+ * ```
+ */
+export class EntitlementFeature extends Resource {
+  public readonly name: string;
+  public readonly lookupKey: string;
+  public readonly metadata?: Record<string, string>;
+
+  constructor(scope: Construct, id: string, props: EntitlementFeatureProps) {
+    super(scope, id, props);
+
+    this.name = props.name;
+    this.lookupKey = props.lookupKey;
+    this.metadata = props.metadata;
+
+    // Register resource metadata after all properties are initialized
+    this.registerResourceMetadata();
+  }
+
+  protected get resourceType(): string {
+    return 'Stripe::EntitlementFeature';
+  }
+
+  protected synthesizeProperties(): Record<string, unknown> {
+    const params: Stripe.Entitlements.FeatureCreateParams = {
+      name: this.name,
+      lookup_key: this.lookupKey,
+    };
+
+    if (this.metadata !== undefined) params.metadata = this.metadata;
+
+    return params as unknown as Record<string, unknown>;
+  }
+}

--- a/packages/constructs/src/index.ts
+++ b/packages/constructs/src/index.ts
@@ -1,3 +1,5 @@
 export * from './product';
 export * from './price';
 export * from './coupon';
+export * from './entitlement';
+export * from './meter';

--- a/packages/constructs/src/meter.ts
+++ b/packages/constructs/src/meter.ts
@@ -1,0 +1,135 @@
+import { Construct, Resource, ResourceProps } from '@pricectl/core';
+import type Stripe from 'stripe';
+
+export interface MeterCustomerMapping {
+  /**
+   * The key in the usage event payload to use for mapping the event to a customer.
+   */
+  readonly eventPayloadKey: string;
+
+  /**
+   * The method for mapping a meter event to a customer. Must be `by_id`.
+   * @default 'by_id'
+   */
+  readonly type?: 'by_id';
+}
+
+export interface MeterValueSettings {
+  /**
+   * The key in the usage event payload to use as the value for this meter.
+   */
+  readonly eventPayloadKey: string;
+}
+
+export interface MeterProps extends ResourceProps {
+  /**
+   * The meter's name, meant to be displayable.
+   */
+  readonly displayName: string;
+
+  /**
+   * The name of the usage event to record usage for.
+   * Corresponds with the `event_name` field on usage events.
+   */
+  readonly eventName: string;
+
+  /**
+   * The default settings to aggregate a meter's events with.
+   */
+  readonly defaultAggregation: {
+    /**
+     * Specifies how events are aggregated. Allowed values are `count` to count the number of events
+     * or `sum` to sum each event's value.
+     */
+    readonly formula: 'count' | 'sum';
+  };
+
+  /**
+   * Fields that specify how to map a meter event to a customer.
+   */
+  readonly customerMapping?: MeterCustomerMapping;
+
+  /**
+   * The time window to pre-aggregate usage events for, if any.
+   */
+  readonly eventTimeWindow?: 'day' | 'hour';
+
+  /**
+   * Fields that specify how to calculate a usage event's value.
+   */
+  readonly valueSettings?: MeterValueSettings;
+}
+
+/**
+ * Represents a Stripe Billing Meter
+ *
+ * A billing meter allows you to track usage of a particular event.
+ * For example, you might create a billing meter to track the number of API calls
+ * made by a particular user.
+ *
+ * @example
+ * ```ts
+ * new Meter(stack, 'ApiCalls', {
+ *   displayName: 'API Calls',
+ *   eventName: 'api_call',
+ *   defaultAggregation: {
+ *     formula: 'count',
+ *   },
+ * });
+ * ```
+ */
+export class Meter extends Resource {
+  public readonly displayName: string;
+  public readonly eventName: string;
+  public readonly defaultAggregation: { readonly formula: 'count' | 'sum' };
+  public readonly customerMapping?: MeterCustomerMapping;
+  public readonly eventTimeWindow?: 'day' | 'hour';
+  public readonly valueSettings?: MeterValueSettings;
+
+  constructor(scope: Construct, id: string, props: MeterProps) {
+    super(scope, id, props);
+
+    this.displayName = props.displayName;
+    this.eventName = props.eventName;
+    this.defaultAggregation = props.defaultAggregation;
+    this.customerMapping = props.customerMapping;
+    this.eventTimeWindow = props.eventTimeWindow;
+    this.valueSettings = props.valueSettings;
+
+    // Register resource metadata after all properties are initialized
+    this.registerResourceMetadata();
+  }
+
+  protected get resourceType(): string {
+    return 'Stripe::BillingMeter';
+  }
+
+  protected synthesizeProperties(): Record<string, unknown> {
+    const params: Stripe.Billing.MeterCreateParams = {
+      display_name: this.displayName,
+      event_name: this.eventName,
+      default_aggregation: {
+        formula: this.defaultAggregation.formula,
+      },
+    };
+
+    if (this.customerMapping !== undefined) {
+      params.customer_mapping = {
+        event_payload_key: this.customerMapping.eventPayloadKey,
+        type: this.customerMapping.type ?? 'by_id',
+      };
+    }
+
+    if (this.eventTimeWindow !== undefined) {
+      params.event_time_window = this.eventTimeWindow;
+    }
+
+    if (this.valueSettings !== undefined) {
+      params.value_settings = {
+        event_payload_key: this.valueSettings.eventPayloadKey,
+      };
+    }
+
+    return params as unknown as Record<string, unknown>;
+  }
+}


### PR DESCRIPTION
The Overview section listed entitlements and meters as current features,
but they are not implemented. Removed them from the overview description
and added Entitlement, Meter, and PromotionCode resources to the v0.2.0
roadmap to align with the "Coming soon" note in the Architecture section.

https://claude.ai/code/session_01AAscfGZAJLSEuKKVdEdj35