### PR TITLE
Remove Node 18 test from CI workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,18 +14,6 @@ workflows:
             - node/install-pnpm:
                 version: '10.29.3'
       - node/test:
-          name: test-node-18
-          pkg-manager: pnpm
-          executor:
-            name: node/default
-            tag: '18.20'
-          setup:
-            - node/install-pnpm:
-                version: '10.29.3'
-          post_install_steps:
-            - run: pnpm build
-          test-results-for: jest
-      - node/test:
           name: test-node-20
           pkg-manager: pnpm
           executor:


### PR DESCRIPTION
Node 18 is no longer actively tested. The CI workflow now runs tests only on Node 20 and Node 22.

https://claude.ai/code/session_01N9gR4miaFDSuv6xreHjqsY